### PR TITLE
State propagation

### DIFF
--- a/src/main/readers/all.ts
+++ b/src/main/readers/all.ts
@@ -192,7 +192,9 @@ export class AllReader<Context> implements ReaderCodegen {
           minimumCount || maximumCount ? [',', readCountVar, '=0'] : '',
           ';',
           'do{',
-          indexVar, '=', readerResultVar, ';',
+
+          // Ensure that we actually use a numeric result
+          indexVar, '=', readerResultVar, '/1;',
           createReaderCallCode(reader, inputVar, indexVar, contextVar, readerResultVar, bindings),
           '}while(',
           readerResultVar, '>', indexVar,

--- a/src/main/readers/end.ts
+++ b/src/main/readers/end.ts
@@ -10,7 +10,7 @@ import {createCodeBindings} from './reader-utils';
  * @see {@link skip}
  */
 export function end(offset = 0): Reader<any> {
-  return new EndReader(offset);
+  return new EndReader(offset | 0);
 }
 
 export class EndReader implements ReaderCodegen {

--- a/src/main/readers/lookahead.ts
+++ b/src/main/readers/lookahead.ts
@@ -28,7 +28,7 @@ export class LookaheadReader<Context> implements ReaderCodegen {
         [
           'var ', readerResultVar, ';',
           createReaderCallCode(this.reader, inputVar, offsetVar, contextVar, readerResultVar, bindings),
-          resultVar, '=', readerResultVar, '<0?', readerResultVar, ':', offsetVar, ';',
+          resultVar, '=', readerResultVar, '>=0?', offsetVar, ':', readerResultVar, ';',
         ],
         bindings,
     );

--- a/src/main/readers/reader-utils.ts
+++ b/src/main/readers/reader-utils.ts
@@ -16,19 +16,19 @@ export function toCharCodes(str: string): number[] {
 
 export function createReaderCallCode<Context>(reader: Reader<Context>, inputVar: Var, offsetVar: Var, contextVar: Var, returnVar: Var, bindings: Binding[]): Code {
 
-  if ('factory' in reader) {
-    const codeBindings = reader.factory(inputVar, offsetVar, contextVar, returnVar);
+  if (typeof reader === 'function') {
+    const readerVar = createVar();
+    bindings.push([readerVar, reader]);
 
-    if (codeBindings.bindings) {
-      bindings.push(...codeBindings.bindings);
-    }
-    return codeBindings.code;
+    return [returnVar, '=', readerVar, '(', inputVar, ',', offsetVar, ',', contextVar, ')', ';'];
   }
 
-  const readerVar = createVar();
-  bindings.push([readerVar, reader]);
+  const codeBindings = reader.factory(inputVar, offsetVar, contextVar, returnVar);
 
-  return [returnVar, '=', readerVar, '(', inputVar, ',', offsetVar, ',', contextVar, ')', ';'];
+  if (codeBindings.bindings) {
+    bindings.push(...codeBindings.bindings);
+  }
+  return codeBindings.code;
 }
 
 export function createCodeBindings(code: Code, bindings?: Binding[]): CodeBindings {
@@ -36,6 +36,7 @@ export function createCodeBindings(code: Code, bindings?: Binding[]): CodeBindin
 }
 
 export function toReaderFunction<Context = void>(reader: Reader<Context>): ReaderFunction<Context> {
+
   if (typeof reader === 'function') {
     return reader;
   }

--- a/src/main/readers/reader-utils.ts
+++ b/src/main/readers/reader-utils.ts
@@ -2,7 +2,7 @@ import {Binding, Code, CodeBindings, compileFunction, createVar, Var} from 'code
 import {Reader, ReaderFunction} from './reader-types';
 
 export function toCharCode(value: string | number): number {
-  return typeof value === 'number' ? value : value.charCodeAt(0);
+  return typeof value === 'number' ? value | 0 : value.charCodeAt(0);
 }
 
 export function toCharCodes(str: string): number[] {

--- a/src/main/readers/seq.ts
+++ b/src/main/readers/seq.ts
@@ -60,8 +60,8 @@ export class SeqReader<Context> implements ReaderCodegen {
           resultVar, '=', readerResultVar,
           '}else{',
 
-          // Ensure that we actually use a numeric value that at least shifts offset forward
-          readerResultVar, '=', readerResultVar, '<', offsetVar, '?', offsetVar, ':', readerResultVar, '/1;',
+          // Ensure that a numeric value is used
+          readerResultVar, '/=1;',
       );
 
       offsetVar = readerResultVar;

--- a/src/main/readers/seq.ts
+++ b/src/main/readers/seq.ts
@@ -54,7 +54,14 @@ export class SeqReader<Context> implements ReaderCodegen {
       code.push(
           'var ', readerResultVar, ';',
           createReaderCallCode(reader, inputVar, offsetVar, contextVar, readerResultVar, bindings),
-          'if(', readerResultVar, '<0){', resultVar, '=', readerResultVar, '}else{'
+
+          // Break seq if NO_MATCH or an error (NaN or < 0)
+          'if(!(', readerResultVar, '>=0)){',
+          resultVar, '=', readerResultVar,
+          '}else{',
+
+          // Ensure that we actually use a numeric value that at least shifts offset forward
+          readerResultVar, '=', readerResultVar, '<', offsetVar, '?', offsetVar, ':', readerResultVar, '/1;',
       );
 
       offsetVar = readerResultVar;

--- a/src/main/readers/skip.ts
+++ b/src/main/readers/skip.ts
@@ -10,7 +10,7 @@ import {createCodeBindings} from './reader-utils';
  * @see {@link end}
  */
 export function skip(charCount: number): Reader<any> {
-  return new SkipReader(charCount);
+  return new SkipReader(Math.max(0, charCount | 0));
 }
 
 export class SkipReader implements ReaderCodegen {

--- a/src/main/readers/until.ts
+++ b/src/main/readers/until.ts
@@ -138,7 +138,7 @@ export class UntilReader<Context> implements ReaderCodegen {
           createReaderCallCode(this.reader, inputVar, indexVar, contextVar, readerResultVar, bindings),
           '++', indexVar,
           '}',
-          resultVar, '=', readerResultVar, '>=0?', this.inclusive ? readerResultVar : [indexVar, '-1'], ':', readerResultVar, ';',
+          resultVar, '=', this.inclusive ? readerResultVar : [readerResultVar, '>=0?', indexVar, '-1:', readerResultVar], ';',
         ],
         bindings,
     );

--- a/src/main/readers/until.ts
+++ b/src/main/readers/until.ts
@@ -138,7 +138,7 @@ export class UntilReader<Context> implements ReaderCodegen {
           createReaderCallCode(this.reader, inputVar, indexVar, contextVar, readerResultVar, bindings),
           '++', indexVar,
           '}',
-          resultVar, '=', readerResultVar, '<', 0, '?', readerResultVar, ':', this.inclusive ? readerResultVar : [indexVar, '-1'], ';',
+          resultVar, '=', readerResultVar, '>=0?', this.inclusive ? readerResultVar : [indexVar, '-1'], ':', readerResultVar, ';',
         ],
         bindings,
     );

--- a/src/main/rules/compileRuleIterator.ts
+++ b/src/main/rules/compileRuleIterator.ts
@@ -96,7 +96,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
         ],
 
         rule.to === undefined ? '' : typeof rule.to === 'function'
-            ? [stageIndexVar, '=', stagesVar, '.indexOf(', ruleToCallbackVar, '(', nextOffsetVar, ',', branchResultVar, '-', nextOffsetVar, ',', contextVar, ',', stateVar, '));']
+            ? [stageIndexVar, '=', stagesVar, '.indexOf(', ruleToCallbackVar, '(', chunkVar, ',', nextOffsetVar, ',', branchResultVar, '-', nextOffsetVar, ',', contextVar, ',', stateVar, '));']
             : [stageIndexVar, '=', stages.indexOf(rule.to), ';'],
 
         nextOffsetVar, '=', branchResultVar, ';',

--- a/src/main/rules/compileRuleIterator.ts
+++ b/src/main/rules/compileRuleIterator.ts
@@ -21,7 +21,6 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
   const stageIndexVar = createVar();
   const chunkVar = createVar();
   const offsetVar = createVar();
-  const chunkOffsetVar = createVar();
 
   const tokenCallbackVar = createVar();
   const errorCallbackVar = createVar();
@@ -77,13 +76,13 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
       code.push([
 
         // Emit an error
-        'if(', branchResultVar, '<0){',
-        errorCallbackVar, '&&', errorCallbackVar, '(', ruleTypeVar, ',', chunkOffsetVar, '+', nextOffsetVar, ',', branchResultVar, ',', contextVar, ',', stateVar, ');',
+        'if(!(', branchResultVar, '>=0)){',
+        errorCallbackVar, '&&', errorCallbackVar, '(', ruleTypeVar, ',', chunkVar, ',', nextOffsetVar, ',', branchResultVar, ',', contextVar, ',', stateVar, ');',
         'return}',
 
         // Emit confirmed token
         'if(', prevRuleIndexVar, '!==-1){',
-        tokenCallbackVar, '(', prevRuleTypeVar, ',', chunkOffsetVar, '+', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
+        tokenCallbackVar, '(', prevRuleTypeVar, ',', chunkVar, ',', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
         prevRuleIndexVar, '=-1}',
 
         // If stagesEnabled === true then stageIndex !== -1
@@ -115,7 +114,6 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
     stageIndexVar, '=', stagesVar, '.indexOf(', stateVar, '.stage),',
     chunkVar, '=', stateVar, '.chunk,',
     offsetVar, '=', stateVar, '.offset,',
-    chunkOffsetVar, '=', stateVar, '.chunkOffset,',
 
     tokenCallbackVar, '=', handlerVar, '.token,',
     errorCallbackVar, '=', handlerVar, '.error,',
@@ -144,7 +142,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
 
     // Emit trailing unconfirmed token
     'if(', prevRuleIndexVar, '!==-1){',
-    tokenCallbackVar, '(', prevRuleTypeVar, ',', chunkOffsetVar, '+', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
+    tokenCallbackVar, '(', prevRuleTypeVar, ',', chunkVar, ',', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
     '}',
 
     // Update stage only if stages are enabled
@@ -154,7 +152,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
     // Trigger unrecognized token
     nextOffsetVar, '!==', chunkLengthVar,
     '&&', unrecognizedTokenCallbackVar,
-    '&&', unrecognizedTokenCallbackVar, '(', chunkOffsetVar, '+', nextOffsetVar, ',', contextVar, ',', stateVar, ');',
+    '&&', unrecognizedTokenCallbackVar, '(', chunkVar, ',', nextOffsetVar, ',', contextVar, ',', stateVar, ');',
   ];
 
   return compileFunction<RuleIterator<Type, Stage, Context>>([stateVar, handlerVar, contextVar, streamingVar], code, bindings);

--- a/src/main/rules/compileRuleIterator.ts
+++ b/src/main/rules/compileRuleIterator.ts
@@ -82,7 +82,8 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
         errorCallbackVar, '&&', errorCallbackVar, '(', ruleTypeVar, ',', chunkVar, ',', nextOffsetVar, ',', branchResultVar, ',', contextVar, ',', stateVar, ');',
         'return}',
 
-        // Ensure that we actually use a numeric value and not an object with valueOf or a string containing digits
+        // Ensure that a numeric value is used
+        // Not an object with valueOf or a string containing digits
         branchResultVar, '/=1;',
 
         // Emit confirmed token

--- a/src/main/rules/compileRuleIterator.ts
+++ b/src/main/rules/compileRuleIterator.ts
@@ -78,12 +78,12 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
 
         // Emit an error
         'if(', branchResultVar, '<0){',
-        errorCallbackVar, '&&', errorCallbackVar, '(', ruleTypeVar, ',', chunkOffsetVar, '+', nextOffsetVar, ',', branchResultVar, ',', contextVar, ');',
+        errorCallbackVar, '&&', errorCallbackVar, '(', ruleTypeVar, ',', chunkOffsetVar, '+', nextOffsetVar, ',', branchResultVar, ',', contextVar, ',', stateVar, ');',
         'return}',
 
         // Emit confirmed token
         'if(', prevRuleIndexVar, '!==-1){',
-        tokenCallbackVar, '(', prevRuleTypeVar, ',', chunkOffsetVar, '+', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ');',
+        tokenCallbackVar, '(', prevRuleTypeVar, ',', chunkOffsetVar, '+', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
         prevRuleIndexVar, '=-1}',
 
         // If stagesEnabled === true then stageIndex !== -1
@@ -96,7 +96,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
         ],
 
         rule.to === undefined ? '' : typeof rule.to === 'function'
-            ? [stageIndexVar, '=', stagesVar, '.indexOf(', ruleToCallbackVar, '(', chunkVar, ',', nextOffsetVar, ',', branchResultVar, '-', nextOffsetVar, ',', contextVar, '));']
+            ? [stageIndexVar, '=', stagesVar, '.indexOf(', ruleToCallbackVar, '(', nextOffsetVar, ',', branchResultVar, '-', nextOffsetVar, ',', contextVar, ',', stateVar, '));']
             : [stageIndexVar, '=', stages.indexOf(rule.to), ';'],
 
         nextOffsetVar, '=', branchResultVar, ';',
@@ -144,7 +144,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
 
     // Emit trailing unconfirmed token
     'if(', prevRuleIndexVar, '!==-1){',
-    tokenCallbackVar, '(', prevRuleTypeVar, ',', chunkOffsetVar, '+', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ');',
+    tokenCallbackVar, '(', prevRuleTypeVar, ',', chunkOffsetVar, '+', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
     '}',
 
     // Update stage only if stages are enabled
@@ -154,7 +154,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
     // Trigger unrecognized token
     nextOffsetVar, '!==', chunkLengthVar,
     '&&', unrecognizedTokenCallbackVar,
-    '&&', unrecognizedTokenCallbackVar, '(', chunkOffsetVar, '+', nextOffsetVar, ',', contextVar, ');',
+    '&&', unrecognizedTokenCallbackVar, '(', chunkOffsetVar, '+', nextOffsetVar, ',', contextVar, ',', stateVar, ');',
   ];
 
   return compileFunction<RuleIterator<Type, Stage, Context>>([stateVar, handlerVar, contextVar, streamingVar], code, bindings);

--- a/src/main/rules/compileRuleIterator.ts
+++ b/src/main/rules/compileRuleIterator.ts
@@ -49,8 +49,9 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
       code.push(
           createReaderCallCode(seq(...branch.readers), chunkVar, branchOffsetVar, contextVar, branchResultVar, bindings),
 
-          // If branch matched and result is an offset that is greater than the current offset, or an error (NaN or < 0)
-          'if(', branchResultVar, '!==', NO_MATCH, '&&(', branchResultVar, '>', branchOffsetVar, '||!(', branchResultVar, '>=0))){',
+          // If the branch matched and the offset is shifted forward (a token has a non-zero length),
+          // or an error (NaN or < 0)
+          'if(', branchResultVar, '!==', NO_MATCH, '&&!(', branchResultVar, '<=', branchOffsetVar, '&&', branchResultVar, '>=0)){',
       );
 
       // Apply nested branches

--- a/src/main/rules/rule-types.ts
+++ b/src/main/rules/rule-types.ts
@@ -37,7 +37,7 @@ export interface Rule<Type = unknown, Stage = void, Context = void> {
    *
    * @default undefined
    */
-  to?: ((offset: number, length: number, context: Context, state: TokenizerState) => Stage) | Stage | undefined;
+  to?: ((chunk: string, offset: number, length: number, context: Context, state: TokenizerState) => Stage) | Stage | undefined;
 
   /**
    * If set to `true` then tokens read by this reader are not emitted.
@@ -96,7 +96,7 @@ export interface TokenHandler<Type = unknown, Context = void> {
    * Triggered when the rule returned an error code.
    *
    * @param type The type of the token as defined in {@link Rule.type}.
-   * @param offset The offset at which the rule was used.
+   * @param offset The absolute offset at which the rule was used.
    * @param errorCode The error code. A negative integer <= -2.
    * @param context The context passed by tokenizer.
    * @param state The current state of the tokenizer.
@@ -106,7 +106,7 @@ export interface TokenHandler<Type = unknown, Context = void> {
   /**
    * Triggered if there was no rule that could successfully read a token at the offset.
    *
-   * @param offset The offset at which the unrecognized token starts.
+   * @param offset The absolute offset at which the unrecognized token starts.
    * @param context The context passed by tokenizer.
    * @param state The current state of the tokenizer.
    */

--- a/src/main/rules/rule-types.ts
+++ b/src/main/rules/rule-types.ts
@@ -84,31 +84,46 @@ export interface TokenHandler<Type = unknown, Context = void> {
   /**
    * Triggered when a token was read from the input stream.
    *
-   * @param type The type of the token as defined in {@link Rule.type}.
-   * @param offset The absolute offset from the start of the input stream where the token starts.
+   * The substring of the current token:
+   *
+   * ```ts
+   * const tokenValue = chunk.substr(offset, length);
+   * ```
+   *
+   * The offset of this token from the start of the input stream (useful if you're using {@link Tokenizer.write}):
+   *
+   * ```ts
+   * const absoluteOffset = state.chunkOffset + offset;
+   * ```
+   *
+   * @param type The type of the token that was read.
+   * @param chunk The input chunk from which the token was read.
+   * @param offset The chunk-relative offset from the start of the input stream where the token starts.
    * @param length The number of chars read by the rule.
-   * @param context The context passed by tokenizer.
+   * @param context The context passed by the tokenizer.
    * @param state The current state of the tokenizer.
    */
-  token(type: Type, offset: number, length: number, context: Context, state: TokenizerState): void;
+  token(type: Type, chunk: string, offset: number, length: number, context: Context, state: TokenizerState): void;
 
   /**
    * Triggered when the rule returned an error code.
    *
-   * @param type The type of the token as defined in {@link Rule.type}.
-   * @param offset The absolute offset at which the rule was used.
-   * @param errorCode The error code. A negative integer <= -2.
-   * @param context The context passed by tokenizer.
+   * @param type The type of the token that caused an error while reading.
+   * @param chunk The input chunk from which the token was read.
+   * @param offset The chunk-relative offset where the token starts.
+   * @param errorCode The error code returned by the reader, a negative number.
+   * @param context The context passed by the tokenizer.
    * @param state The current state of the tokenizer.
    */
-  error?(type: Type, offset: number, errorCode: number, context: Context, state: TokenizerState): void;
+  error?(type: Type, chunk: string, offset: number, errorCode: number, context: Context, state: TokenizerState): void;
 
   /**
    * Triggered if there was no rule that could successfully read a token at the offset.
    *
-   * @param offset The absolute offset at which the unrecognized token starts.
-   * @param context The context passed by tokenizer.
+   * @param chunk The input chunk from which tokens are read.
+   * @param offset The chunk-relative offset where the unrecognized token starts.
+   * @param context The context passed by the tokenizer.
    * @param state The current state of the tokenizer.
    */
-  unrecognizedToken?(offset: number, context: Context, state: TokenizerState): void;
+  unrecognizedToken?(chunk: string, offset: number, context: Context, state: TokenizerState): void;
 }

--- a/src/main/rules/rule-types.ts
+++ b/src/main/rules/rule-types.ts
@@ -37,7 +37,7 @@ export interface Rule<Type = unknown, Stage = void, Context = void> {
    *
    * @default undefined
    */
-  to?: ((input: string, offset: number, length: number, context: Context) => Stage) | Stage | undefined;
+  to?: ((offset: number, length: number, context: Context, state: TokenizerState) => Stage) | Stage | undefined;
 
   /**
    * If set to `true` then tokens read by this reader are not emitted.
@@ -88,8 +88,9 @@ export interface TokenHandler<Type = unknown, Context = void> {
    * @param offset The absolute offset from the start of the input stream where the token starts.
    * @param length The number of chars read by the rule.
    * @param context The context passed by tokenizer.
+   * @param state The current state of the tokenizer.
    */
-  token(type: Type, offset: number, length: number, context: Context): void;
+  token(type: Type, offset: number, length: number, context: Context, state: TokenizerState): void;
 
   /**
    * Triggered when the rule returned an error code.
@@ -98,14 +99,16 @@ export interface TokenHandler<Type = unknown, Context = void> {
    * @param offset The offset at which the rule was used.
    * @param errorCode The error code. A negative integer <= -2.
    * @param context The context passed by tokenizer.
+   * @param state The current state of the tokenizer.
    */
-  error?(type: Type, offset: number, errorCode: number, context: Context): void;
+  error?(type: Type, offset: number, errorCode: number, context: Context, state: TokenizerState): void;
 
   /**
    * Triggered if there was no rule that could successfully read a token at the offset.
    *
    * @param offset The offset at which the unrecognized token starts.
    * @param context The context passed by tokenizer.
+   * @param state The current state of the tokenizer.
    */
-  unrecognizedToken?(offset: number, context: Context): void;
+  unrecognizedToken?(offset: number, context: Context, state: TokenizerState): void;
 }

--- a/src/test/createTokenizer.test.ts
+++ b/src/test/createTokenizer.test.ts
@@ -2,14 +2,20 @@ import {all, char, createTokenizer, NO_MATCH, ReaderFunction, Rule, text, TokenH
 
 describe('createTokenizer', () => {
 
-  let tokenCallbackMock = jest.fn();
-  let errorCallbackMock = jest.fn();
-  let unrecognizedTokenCallbackMock = jest.fn();
+  const tokenCallbackMock = jest.fn();
+  const errorCallbackMock = jest.fn();
+  const unrecognizedTokenCallbackMock = jest.fn();
 
   const handler: TokenHandler = {
-    token: tokenCallbackMock,
-    error: errorCallbackMock,
-    unrecognizedToken: unrecognizedTokenCallbackMock,
+    token(type, offset, length, context, /*state*/) {
+      tokenCallbackMock(type, offset, length, context, /*{...state}*/);
+    },
+    error(type, offset, errorCode, context, /*state*/) {
+      errorCallbackMock(type, offset, errorCode, context, /*{...state}*/);
+    },
+    unrecognizedToken(offset, context, /*state*/) {
+      unrecognizedTokenCallbackMock(offset, context, /*{...state}*/);
+    }
   };
 
   beforeEach(() => {

--- a/src/test/createTokenizer.test.ts
+++ b/src/test/createTokenizer.test.ts
@@ -7,14 +7,14 @@ describe('createTokenizer', () => {
   const unrecognizedTokenCallbackMock = jest.fn();
 
   const handler: TokenHandler = {
-    token(type, offset, length, context, /*state*/) {
-      tokenCallbackMock(type, offset, length, context, /*{...state}*/);
+    token(type, chunk, offset, length, context, state) {
+      tokenCallbackMock(type, state.chunkOffset + offset, length, context);
     },
-    error(type, offset, errorCode, context, /*state*/) {
-      errorCallbackMock(type, offset, errorCode, context, /*{...state}*/);
+    error(type, chunk, offset, errorCode, context, state) {
+      errorCallbackMock(type, state.chunkOffset + offset, errorCode, context);
     },
-    unrecognizedToken(offset, context, /*state*/) {
-      unrecognizedTokenCallbackMock(offset, context, /*{...state}*/);
+    unrecognizedToken(chunk, offset, context, state) {
+      unrecognizedTokenCallbackMock(state.chunkOffset + offset, context);
     }
   };
 

--- a/src/test/perf.js
+++ b/src/test/perf.js
@@ -1,7 +1,82 @@
+const packageLockJson = require('../../package-lock.json');
+const packageJson = require('../../package.json');
 const latest = require('tokenizer-dsl');
 const next = require('../../lib/index-cjs');
 
-describe('readme', () => {
+const baseVersion = 'v' + packageLockJson.dependencies['tokenizer-dsl'].version;
+const nextVersion = 'v' + packageJson.version;
+
+describe('Tokenizer', () => {
+  test('End-to-end', (measure) => {
+
+    const zeroReader = next.text('0');
+
+    const leadingDigitReader = next.char([['1', '9']]);
+
+    const digitsReader = next.all(next.char([['0', '9']]));
+
+    const dotReader = next.text('.');
+
+    const signReader = next.char(['+-']);
+
+    const numberReader = next.seq(
+        // sign
+        next.maybe(signReader),
+
+        // integer
+        next.or(
+            zeroReader,
+            next.seq(
+                leadingDigitReader,
+                digitsReader,
+            ),
+        ),
+
+        // fraction
+        next.maybe(
+            next.seq(
+                dotReader,
+                digitsReader,
+            ),
+        ),
+    );
+
+    const semicolonReader = next.text(';');
+
+    const whitespaceReader = next.all(next.char([' \t\n\r']));
+
+    const tokenizer = next.createTokenizer([
+      {
+        on: [0],
+        type: 'NUMBER',
+        reader: numberReader,
+        to: 1,
+      },
+      {
+        on: [1],
+        reader: semicolonReader,
+        silent: true,
+        to: 0,
+      },
+      {
+        reader: whitespaceReader,
+        silent: true,
+      },
+    ], 0);
+
+    const handler = {
+      token(chunk, type, offset, length, context, state) {
+        context.fooBar = state.chunkOffset + offset;
+      },
+    };
+
+    measure(() => tokenizer('123.456; +777; -42', handler, {fooBar: 0}));
+
+  });
+
+}, {targetRme: 0.001});
+
+describe('Readme', () => {
 
   const input = 'aaaaa-123.123aaaaa';
 
@@ -13,7 +88,7 @@ describe('readme', () => {
     });
   });
 
-  test('latest', (measure) => {
+  test(baseVersion, (measure) => {
 
     const readZero = latest.char(48 /*0*/);
 
@@ -50,7 +125,7 @@ describe('readme', () => {
     measure(() => readNumber(input, 5));
   });
 
-  test('next', (measure) => {
+  test(nextVersion, (measure) => {
     const zeroReader = next.text('0');
 
     const leadingDigitReader = next.char([['1', '9']]);
@@ -103,12 +178,12 @@ describe('char', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.charBy((charCode) => charCode === 97 || charCode === 98);
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.char(['ab']));
       measure(() => read(input, 0));
     });
@@ -129,12 +204,12 @@ describe('all', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.allCharBy((charCode) => charCode === 97 || charCode === 98);
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.all(next.char(['ab'])));
       measure(() => read(input, 0));
     });
@@ -152,12 +227,12 @@ describe('all', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.allCharBy((charCode) => charCode === 97 || charCode === 98, 2);
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.all(next.char(['ab']), {minimumCount: 2}));
       measure(() => read(input, 0));
     });
@@ -175,12 +250,12 @@ describe('all', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.allCharBy((charCode) => charCode === 97 || charCode === 98, 0, 3);
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.all(next.char(['ab']), {maximumCount: 3}));
       measure(() => read(input, 0));
     });
@@ -198,12 +273,12 @@ describe('all', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.allCharBy((charCode) => charCode === 97 || charCode === 98, 2, 3);
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.all(next.char(['ab']), {minimumCount: 2, maximumCount: 3}));
       measure(() => read(input, 0));
     });
@@ -221,12 +296,12 @@ describe('all', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.allCharBy((charCode) => charCode === 97 || charCode === 98, 2, 2);
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.all(next.char(['ab']), {minimumCount: 2, maximumCount: 2}));
       measure(() => read(input, 0));
     });
@@ -244,12 +319,12 @@ describe('all', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.all(latest.text('ab'));
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.all(next.text('ab')));
       measure(() => read(input, 0));
     });
@@ -267,12 +342,12 @@ describe('all', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.all(latest.text('ab'));
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.all(next.regex(/ab/)));
       measure(() => read(input, 0));
     });
@@ -293,12 +368,12 @@ describe('or', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.or(latest.char(99), latest.char(98), latest.char(97));
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.or(next.text('c'), next.text('b'), next.text('a')));
       measure(() => read(input, 0));
     });
@@ -319,12 +394,12 @@ describe('seq', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.seq(latest.char(97), latest.char(97), latest.char(97));
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.seq(next.text('a'), next.text('a'), next.text('a')));
       measure(() => read(input, 0));
     });
@@ -345,12 +420,12 @@ describe('text', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.text('ababa');
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.text('ababa'));
       measure(() => read(input, 0));
     });
@@ -368,12 +443,12 @@ describe('text', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.text('ABABA', true);
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.text('ABABA', {caseInsensitive: true}));
       measure(() => read(input, 0));
     });
@@ -394,12 +469,12 @@ describe('until', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.untilCharBy((charCode) => charCode === 98 || charCode === 99, false, false);
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.until(next.char(['ab'])));
       measure(() => read(input, 0));
     });
@@ -421,12 +496,12 @@ describe('until', () => {
       measure(() => input.indexOf('bc'));
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.untilText('bc', false, false);
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.until(next.text('bc')));
       measure(() => read(input, 0));
     });
@@ -444,12 +519,12 @@ describe('until', () => {
       });
     });
 
-    test('latest', (measure) => {
+    test(baseVersion, (measure) => {
       const read = latest.untilCharBy((charCode) => charCode === 98, false, false);
       measure(() => read(input, 0));
     });
 
-    test('next', (measure) => {
+    test(nextVersion, (measure) => {
       const read = next.toReaderFunction(next.until(next.regex(/b/)));
       measure(() => read(input, 0));
     });

--- a/src/test/rules/compileRuleIterator.test.ts
+++ b/src/test/rules/compileRuleIterator.test.ts
@@ -3,9 +3,9 @@ import {compileRuleIterator, createRuleTree, TokenHandler, TokenizerState} from 
 
 describe('compileRuleIterator', () => {
 
-  let tokenCallbackMock = jest.fn();
-  let errorCallbackMock = jest.fn();
-  let unrecognizedTokenCallbackMock = jest.fn();
+  const tokenCallbackMock = jest.fn();
+  const errorCallbackMock = jest.fn();
+  const unrecognizedTokenCallbackMock = jest.fn();
 
   const handler: TokenHandler<any, any> = {
     token: tokenCallbackMock,

--- a/src/test/rules/compileRuleIterator.test.ts
+++ b/src/test/rules/compileRuleIterator.test.ts
@@ -281,8 +281,8 @@ describe('compileRuleIterator', () => {
     const ruleAToMock = jest.fn<string, any[]>(() => 'B');
     const ruleBToMock = jest.fn<string, any[]>(() => 'A');
 
-    const ruleA: Rule<string, string, symbol> = {type: 'TypeA', reader: text('a'), on: ['A'], to: (offset, length, context, state) => ruleAToMock(offset, length, context, {...state})};
-    const ruleB: Rule<string, string, symbol> = {type: 'TypeB', reader: text('b'), on: ['B'], to: (offset, length, context, state) => ruleBToMock(offset, length, context, {...state})};
+    const ruleA: Rule<string, string, symbol> = {type: 'TypeA', reader: text('a'), on: ['A'], to: (chunk, offset, length, context, state) => ruleAToMock(chunk, offset, length, context, {...state})};
+    const ruleB: Rule<string, string, symbol> = {type: 'TypeB', reader: text('b'), on: ['B'], to: (chunk, offset, length, context, state) => ruleBToMock(chunk, offset, length, context, {...state})};
 
     const ruleIterator = compileRuleIterator(createRuleTree([ruleA, ruleB]));
 
@@ -306,12 +306,12 @@ describe('compileRuleIterator', () => {
     expect(unrecognizedTokenCallbackMock).not.toHaveBeenCalled();
 
     expect(ruleAToMock).toHaveBeenCalledTimes(2);
-    expect(ruleAToMock).toHaveBeenNthCalledWith(1, 0, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 0, stage: 'A'});
-    expect(ruleAToMock).toHaveBeenNthCalledWith(2, 2, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 2, stage: 'A'});
+    expect(ruleAToMock).toHaveBeenNthCalledWith(1, 'ababbbb', 0, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 0, stage: 'A'});
+    expect(ruleAToMock).toHaveBeenNthCalledWith(2, 'ababbbb', 2, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 2, stage: 'A'});
 
     expect(ruleBToMock).toHaveBeenCalledTimes(2);
-    expect(ruleBToMock).toHaveBeenNthCalledWith(1, 1, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 1, stage: 'B'});
-    expect(ruleBToMock).toHaveBeenNthCalledWith(2, 3, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 3, stage: 'B'});
+    expect(ruleBToMock).toHaveBeenNthCalledWith(1, 'ababbbb', 1, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 1, stage: 'B'});
+    expect(ruleBToMock).toHaveBeenNthCalledWith(2, 'ababbbb', 3, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 3, stage: 'B'});
 
     expect(state).toEqual({
       chunk: 'ababbbb',

--- a/src/test/rules/compileRuleIterator.test.ts
+++ b/src/test/rules/compileRuleIterator.test.ts
@@ -8,14 +8,14 @@ describe('compileRuleIterator', () => {
   const unrecognizedTokenCallbackMock = jest.fn();
 
   const handler: TokenHandler<any, any> = {
-    token(type, offset, length, context, /*state*/) {
-      tokenCallbackMock(type, offset, length, context, /*{...state}*/);
+    token(type, chunk, offset, length, context, state) {
+      tokenCallbackMock(type, state.chunkOffset + offset, length, context);
     },
-    error(type, offset, errorCode, context, /*state*/) {
-      errorCallbackMock(type, offset, errorCode, context, /*{...state}*/);
+    error(type, chunk, offset, errorCode, context, state) {
+      errorCallbackMock(type, state.chunkOffset + offset, errorCode, context);
     },
-    unrecognizedToken(offset, context, /*state*/) {
-      unrecognizedTokenCallbackMock(offset, context, /*{...state}*/);
+    unrecognizedToken(chunk, offset, context, state) {
+      unrecognizedTokenCallbackMock(state.chunkOffset + offset, context);
     }
   };
 
@@ -278,11 +278,11 @@ describe('compileRuleIterator', () => {
   });
 
   test('respects computed stages', () => {
-    const ruleAToMock = jest.fn<string, any[]>(() => 'B');
-    const ruleBToMock = jest.fn<string, any[]>(() => 'A');
+    const ruleAToMock = jest.fn(() => 'B');
+    const ruleBToMock = jest.fn(() => 'A');
 
-    const ruleA: Rule<string, string, symbol> = {type: 'TypeA', reader: text('a'), on: ['A'], to: (chunk, offset, length, context, state) => ruleAToMock(chunk, offset, length, context, {...state})};
-    const ruleB: Rule<string, string, symbol> = {type: 'TypeB', reader: text('b'), on: ['B'], to: (chunk, offset, length, context, state) => ruleBToMock(chunk, offset, length, context, {...state})};
+    const ruleA: Rule<string, string, symbol> = {type: 'TypeA', reader: text('a'), on: ['A'], to: ruleAToMock};
+    const ruleB: Rule<string, string, symbol> = {type: 'TypeB', reader: text('b'), on: ['B'], to: ruleBToMock};
 
     const ruleIterator = compileRuleIterator(createRuleTree([ruleA, ruleB]));
 
@@ -306,12 +306,12 @@ describe('compileRuleIterator', () => {
     expect(unrecognizedTokenCallbackMock).not.toHaveBeenCalled();
 
     expect(ruleAToMock).toHaveBeenCalledTimes(2);
-    expect(ruleAToMock).toHaveBeenNthCalledWith(1, 'ababbbb', 0, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 0, stage: 'A'});
-    expect(ruleAToMock).toHaveBeenNthCalledWith(2, 'ababbbb', 2, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 2, stage: 'A'});
+    expect(ruleAToMock).toHaveBeenNthCalledWith(1, 'ababbbb', 0, 1, context, expect.anything());
+    expect(ruleAToMock).toHaveBeenNthCalledWith(2, 'ababbbb', 2, 1, context, expect.anything());
 
     expect(ruleBToMock).toHaveBeenCalledTimes(2);
-    expect(ruleBToMock).toHaveBeenNthCalledWith(1, 'ababbbb', 1, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 1, stage: 'B'});
-    expect(ruleBToMock).toHaveBeenNthCalledWith(2, 'ababbbb', 3, 1, context, {chunk: 'ababbbb', chunkOffset: 0, offset: 3, stage: 'B'});
+    expect(ruleBToMock).toHaveBeenNthCalledWith(1, 'ababbbb', 1, 1, context, expect.anything());
+    expect(ruleBToMock).toHaveBeenNthCalledWith(2, 'ababbbb', 3, 1, context, expect.anything());
 
     expect(state).toEqual({
       chunk: 'ababbbb',


### PR DESCRIPTION
- Propagate `TokenizerState` and chunk as arguments to `TokenHandler` callbacks (the number of arguments doesn't seem to affect performance);
- Results returned from readers are now normalized to a number on success, and on error, `NaN` and negative numbers (except `NO_MATCH` == -1) are returned as is;