### PR TITLE
Readonly tokenizer state

### DIFF
--- a/src/main/rules/rule-types.ts
+++ b/src/main/rules/rule-types.ts
@@ -37,7 +37,7 @@ export interface Rule<Type = unknown, Stage = void, Context = void> {
    *
    * @default undefined
    */
-  to?: ((chunk: string, offset: number, length: number, context: Context, state: TokenizerState) => Stage) | Stage | undefined;
+  to?: ((chunk: string, offset: number, length: number, context: Context, state: Readonly<TokenizerState>) => Stage) | Stage | undefined;
 
   /**
    * If set to `true` then tokens read by this reader are not emitted.
@@ -103,7 +103,7 @@ export interface TokenHandler<Type = unknown, Context = void> {
    * @param context The context passed by the tokenizer.
    * @param state The current state of the tokenizer.
    */
-  token(type: Type, chunk: string, offset: number, length: number, context: Context, state: TokenizerState): void;
+  token(type: Type, chunk: string, offset: number, length: number, context: Context, state: Readonly<TokenizerState>): void;
 
   /**
    * Triggered when the rule returned an error code.
@@ -115,7 +115,7 @@ export interface TokenHandler<Type = unknown, Context = void> {
    * @param context The context passed by the tokenizer.
    * @param state The current state of the tokenizer.
    */
-  error?(type: Type, chunk: string, offset: number, errorCode: number, context: Context, state: TokenizerState): void;
+  error?(type: Type, chunk: string, offset: number, errorCode: number, context: Context, state: Readonly<TokenizerState>): void;
 
   /**
    * Triggered if there was no rule that could successfully read a token at the offset.
@@ -125,5 +125,5 @@ export interface TokenHandler<Type = unknown, Context = void> {
    * @param context The context passed by the tokenizer.
    * @param state The current state of the tokenizer.
    */
-  unrecognizedToken?(chunk: string, offset: number, context: Context, state: TokenizerState): void;
+  unrecognizedToken?(chunk: string, offset: number, context: Context, state: Readonly<TokenizerState>): void;
 }

--- a/src/test/createTokenizer.test.ts
+++ b/src/test/createTokenizer.test.ts
@@ -48,6 +48,19 @@ describe('createTokenizer', () => {
     expect(tokenCallbackMock).toHaveBeenNthCalledWith(3, 'TypeB', 2, 3, undefined);
   });
 
+  test('reads tokens', () => {
+    const rule: Rule = {type: 'TypeA', reader: text('a')};
+
+    const tokenizer = createTokenizer([rule]);
+
+    const state1 = tokenizer.write('aaa', handler);
+    const state2 = tokenizer.write('aaa', handler, state1);
+    const state3 = tokenizer.end(handler, state2);
+
+    expect(state1).not.toBe(state2);
+    expect(state2).not.toBe(state3);
+  });
+
   test('reads streaming tokens', () => {
     const ruleA: Rule = {type: 'TypeA', reader: text('a')};
     const ruleB: Rule = {type: 'TypeB', reader: all(char(['b'.charCodeAt(0), 'B'.charCodeAt(0)]))};
@@ -57,17 +70,19 @@ describe('createTokenizer', () => {
       ruleB,
     ]);
 
-    const state = tokenizer.write('aabbb', handler);
+    let state;
+
+    state = tokenizer.write('aabbb', handler);
 
     expect(tokenCallbackMock).toHaveBeenCalledTimes(2);
     expect(tokenCallbackMock).toHaveBeenNthCalledWith(1, 'TypeA', 0, 1, undefined);
     expect(tokenCallbackMock).toHaveBeenNthCalledWith(2, 'TypeA', 1, 1, undefined);
 
-    tokenizer.write('BBB', handler, state);
+    state = tokenizer.write('BBB', handler, state);
 
     expect(tokenCallbackMock).toHaveBeenCalledTimes(2);
 
-    tokenizer.write('a', handler, state);
+    state = tokenizer.write('a', handler, state);
 
     expect(tokenCallbackMock).toHaveBeenCalledTimes(3);
     expect(tokenCallbackMock).toHaveBeenNthCalledWith(3, 'TypeB', 2, 6, undefined);


### PR DESCRIPTION
`Tokenizer` doesn't mutate the provided state object.