### PR TITLE
Simpler API; Inline integer stages and token types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 The API for building streaming tokenizers and lexers.
 
-- [2× faster than `RegExp`-base alternatives](#performance);
-- Less than [3 kB gzipped](https://bundlephobia.com/result?p=tokenizer-dsl) including dependencies;
+- [2× faster than `RegExp`-based alternatives](#performance);
+- [3.5 kB gzipped](https://bundlephobia.com/result?p=tokenizer-dsl) including dependencies;
+- No heap allocations during tokenization;
 - Compiled tokenizer is a pure function;
-- No memory allocations during tokenization;
 
 ```shell
 npm install --save-prod tokenizer-dsl

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ readers as a code factories.
 Let's recreate the reader from the previous section with the codegen approach:
 
 ```ts
-import {Reader, NO_MATCH} from 'tokenizer-dsl';
+import {Reader} from 'tokenizer-dsl';
 
 const fooReader: Reader = {
 

--- a/README.md
+++ b/README.md
@@ -148,11 +148,8 @@ As the last step, we should call a tokenizer and provide it an input and a token
 ```ts
 import {TokenHandler} from 'tokenizer-dsl';
 
-const handler: TokenHandler = {
-
-  token(type, input, offset, length, context, state) {
-    console.log(type, input.substr(offset, length));
-  }
+const handler: TokenHandler = (type, input, offset, length, context, state) => {
+  console.log(type, input.substr(offset, length));
 };
 
 tokenize('123.456; aaa; +777; bbb; -42', handler);
@@ -171,34 +168,6 @@ NUMBER +777
 SEMICOLON ;
 WHITESPACE  
 NUMBER -42
-```
-
-To capture unrecognized tokens you can add an `unrecognizedToken` callback to the handler:
-
-```ts
-const handler: TokenHandler = {
-
-  token(type, input, offset, length, context, state) {
-    console.log(type, input.substr(offset, length));
-  },
-
-  unrecognizedToken(offset, context) {
-    console.log('Unrecognized token at position', offset);
-  }
-};
-```
-
-Let's test it with a malformed input. Notice the `'_'` char that isn't recognized by tokenization rules that we defined:
-
-```ts
-tokenize('abc_', handler);
-```
-
-The console output would be:
-
-```
-ALPHA abc
-Unrecognized token at position 4
 ```
 
 # Built-in readers

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 The API for building streaming tokenizers and lexers.
 
 - [2× faster than `RegExp`-based alternatives](#performance);
-- [3.5 kB gzipped](https://bundlephobia.com/result?p=tokenizer-dsl) including dependencies;
+- [3 kB gzipped](https://bundlephobia.com/result?p=tokenizer-dsl) including dependencies;
+- Supports streaming out of the box;
 - No heap allocations during tokenization;
-- Compiled tokenizer is a pure function;
 
 ```shell
 npm install --save-prod tokenizer-dsl
@@ -19,45 +19,40 @@ npm install --save-prod tokenizer-dsl
 - [Rules](#rules)
     - [Rule stages](#rule-stages)
     - [Silent rules](#silent-rules)
-- [Context](#context)
-- [Error handling](#error-handling)
 - [Streaming](#streaming)
+- [Context](#context)
 - [Performance](#performance)
 
 # Usage
 
-The extensive example below shows how to define readers, and compile a pure tokenizer function that would read a list of
-signed floating-point numbers separated by a semicolon.
-
-Let's consider the input string that contains lowercase-alpha strings and floating-point numbers separated by a single
+Let's consider the input string that contains lowercase-alpha strings and floating-point numbers, separated by a
 semicolon and an arbitrary number of space characters:
 
 ```ts
 '123.456; aaa; +777; bbb; -42'
 ```
 
-First we need to describe [readers](#readers) that would read chars from the input string. Readers are described
-in-depth in [Readers](#readers) chapter.
+To tokenize this string we first need to describe readers that would read chars from the input string.
 
-Readers for semicolons and whitespaces are pretty straightforward:
+The reader for semicolons is pretty straightforward:
 
 ```ts
 import {all, char, text} from 'tokenizer-dsl';
 
 const semicolonReader = text(';');
-
-const whitespaceReader = all(char([' \t\n\r']));
 ```
 
-To read a lowercase-alpha string we would use the combination of `all` and `char` readers with `minimumCount` option:
+To read a sequence of whitespaces or lowercase-alpha string we would use the combination of `all` and `char` readers:
 
 ```ts
 import {all, char} from 'tokenizer-dsl';
 
+const whitespaceReader = all(char([' \t\n\r']));
+
 const alphaReader = all(char([['a', 'z']]), {minimumCount: 1});
 ```
 
-This reader works the same way as `/[a-z]+/y`.
+The `RegExp` equivalent for `whitespaceReader` if `/[ \t\n\r]*/y`, and for `alphaReader` it is `/[a-z]+/y`.
 
 To read a signed floating-point number we need a combination of multiple readers:
 
@@ -130,7 +125,7 @@ a number, an object, or any other data type.
 
 `reader` is the reader that actually reads the chars from the string.
 
-The next step is to create a tokenizer and provide it a set of rules:
+The next step is to create a tokenizer that uses our rules:
 
 ```ts
 const tokenize = createTokenizer([
@@ -217,10 +212,10 @@ Reads substring using the `RegExp` pattern:
 
 ```ts
 // Reads '0', '123', etc.
-regex(/0|[1-9]\d*/);
+regex(/0|[1-9]\d*/y);
 ```
 
-You don't need to specify `g` or `y` flags on the `RegExp`, these flags are automatically added if needed.
+If you don't specify `g` or `y` flags on the `RegExp`, then `y` is implicitly added.
 
 ### `all(reader, options?)`<a name="all"></a>
 
@@ -343,16 +338,15 @@ The singleton reader that always returns the current offset.
 A reader can be defined as a function that takes an `input` string, an `offset` at which it should start reading, and a
 `context`. Learn more about the context in the [Context](#context) section.
 
-A reader should return the new offset that is greater or equal to `offset` if it has successfully read from the `input`,
-or any integer less than `offset` to indicate that nothing was read. If reader returns a non-number value it is treated
-as an error and passed to the `error` callback of the `TokenHandler`.
+A reader should return the new offset that is greater or equal to `offset` if the reader has successfully read from
+the `input`, or an integer less than `offset` to indicate that nothing was read.
 
 Let's create a custom reader:
 
 ```ts
 import {Reader} from 'tokenizer-dsl';
 
-const fooReader: Reader = (input, offset, context) => {
+const fooReader: Reader = (input, offset) => {
   return input.startsWith('foo', offset) ? offset + 3 : -1;
 };
 ```
@@ -435,11 +429,11 @@ We can combine `substring` with any built-in reader. For example, to read all se
 ```ts
 import {all} from 'tokenizer-dsl';
 
-// Reads all consequent 'foo' substrings
+// Reads consequent 'foo' substrings
 all(substring('foo'));
 ```
 
-You can introduce custom variables inside a code template. Below is an example of a reader that reads zero-or-more lower
+You can introduce custom variables inside a code template. Here is an example of a reader that reads zero-or-more lower
 alpha chars from the string using a `for` loop:
 
 ```ts
@@ -463,7 +457,7 @@ const lowerAlphaReader: Reader = {
         'while(', indexVar, '<', inputVar, '.length){',
 
         // Read the char code from the input
-        'var ', charCodeVar, '=', indexVar, '.charCodeAt(', indexVar, ');',
+        'var ', charCodeVar, '=', inputVar, '.charCodeAt(', indexVar, ');',
 
         // Abort the loop if the char code isn't a lower alpha
         'if(', charCodeVar, '<', 'a'.charCodeAt(0), '||', charCodeVar, '>', 'z'.charCodeAt(0), ')',
@@ -487,7 +481,7 @@ You can find out more details on how codegen works in the [codedegen](https://gi
 
 Rules define how tokens are emitted when successfully read from the input by readers.
 
-The most basic rule only declares a reader that must be used:
+The most basic rule only defines a reader:
 
 ```ts
 import {Rule} from 'tokenizer-dsl';
@@ -506,12 +500,9 @@ const tokenize = createTokenizer([fooRule]);
 Now you can read inputs that consist of any number of `'foo'` substrings:
 
 ```ts
-tokenize('foofoofoo', {
-
-  token(type, input, offset, length, context) {
-    // Process the token here
-  }
-})
+tokenize('foofoofoo', (type, input, offset, length, context) => {
+  // Process the token here
+});
 ```
 
 Most of the time you have more than one token type in your input. Here the `type` property of the rule comes handy. The
@@ -538,21 +529,18 @@ const tokenize = createTokenizer([
   barRule
 ]);
 
-tokenize('foofoobarfoobar', {
+tokenize('foofoobarfoobar', (type, input, offset, length, context) => {
+  switch (type) {
 
-  token(type, input, offset, length, context) {
-    switch (type) {
+    case 'FOO':
+      // Process the FOO token here
+      break;
 
-      case 'FOO':
-        // Process the FOO token here
-        break;
-
-      case 'BAR':
-        // Process the BAR token here
-        break;
-    }
+    case 'BAR':
+      // Process the BAR token here
+      break;
   }
-})
+});
 ```
 
 ## Rule stages
@@ -560,8 +548,7 @@ tokenize('foofoobarfoobar', {
 You can put rules on different stages to control how they are applied.
 
 In the previous example we created a tokenizer that reads `'foo'` and `'bar'` in any order. Let's create a tokenizer
-that
-restricts an order in which `'foo'` and `'bar'` should be met.
+that restricts an order in which `'foo'` and `'bar'` should be met.
 
 ```ts
 import {Rule} from 'tokenizer-dsl';
@@ -600,7 +587,7 @@ const tokenize = createTokenizer(
 );
 ```
 
-This tokenizer would successfully process `'foobarfoobar'` but would trigger `unrecognizedToken` for `'foofoo'`.
+This tokenizer would successfully process `'foobarfoobar'` but would stop on `'foofoo'`.
 
 Rules that don't have `on` option specified are applied on all stages. To showcase this behavior, let's modify our rules
 to allow `'foo'` and `'bar'` to be separated with arbitrary number of space characters.
@@ -640,7 +627,7 @@ const tokenize = createTokenizer(
 );
 ```
 
-This tokenizer would successfully process `'foo bar foo bar'` input.
+This tokenizer would successfully process `' foo bar foo bar '` input.
 
 You can provide a callback that returns the next stage:
 
@@ -659,8 +646,8 @@ const barRule: Rule<MyTokenType, MyStage> = {
 
 ## Silent rules
 
-Sometimes tokens don't have any semantics that you want to process. In this case, you can mark reader as `silent` to
-prevent token from being emitted.
+Some tokens don't have any semantics that you want to process. In this case, you can mark rule as `silent` to prevent
+token from being emitted.
 
 ```ts
 const whitespaceRule: Rule = {
@@ -671,8 +658,8 @@ const whitespaceRule: Rule = {
 
 # Streaming
 
-Compiled tokenizer supports streaming out of the box. Let's refer to the tokenizer we defined in the [Usage](#usage)
-chapter:
+Compiled tokenizer supports streaming out of the box. Let's refer to the tokenizer that we defined in
+the [Usage](#usage) chapter:
 
 ```ts
 const tokenize = createTokenizer([
@@ -694,67 +681,38 @@ If the input string comes in chunks we can use a streaming API of the tokenizer:
 ```ts
 import {TokenizerState} from 'tokeinzer-dsl';
 
-let state: TokenizerState | undefined;
-
-state = tokenizer.write('123.456', handler, state);
-state = tokenizer.write('; aaa; +777; bbb; -42', handler, state);
-state = tokenizer.end(handler, state);
+const state = tokenizer.write('123.456', handler);
+tokenizer.write('; aaa; +77', handler, state);
+tokenizer.write('7; bbb; -42', handler, state);
+tokenizer.end(handler, state);
 ```
 
-`tokenizer.write` accepts an immutable state object and returns the new state object. You can inspect state to know the
-stage and offset at which the tokenizer finished reading tokens.
+`tokenizer.write` accepts a mutable state object that is updated as tokenization progresses. You can inspect state to
+know the stage and offset at which the tokenizer finished reading tokens.
 
 Streaming tokenizer emits tokens that are _confirmed_. The token is confirmed after the consequent token is
 successfully read or after the `tokenizer.end` is called.
 
-# Error handling
-
-Your custom readers may return errors to trigger `error` callback of the `TokenHandler` passed to the tokenizer. Any
-non-number value returned from the reader is treated as an error.
-
-For example, we can implement a reader that reads a quoted string from the input. If the string doesn't have the end
-quote, the reader would trigger an error.
-
-```ts
-import {Reader} from 'tokenizer-dsl';
-
-const quotedStringReader: Reader = (input, offset) => {
-
-  // String must start with a quote char, otherwise no match
-  if (input.charAt(offset) !== '"') {
-    return -1;
-  }
-
-  // Search for closing quote
-  const endOffset = input.indexOf('"', offset + 1);
-
-  if (endOffset === -1) {
-    // Trigger an error
-    return 'Unterminated string';
-  }
-
-  return endOffset;
-};
-```
-
 # Context
 
-Tokenizer is a pure function of its state. Sometimes you want to pass your custom state to the tokenizer to your custom
-readers would know what to do. You can provide the context to the tokenizer, and it would pass it to all readers as a
-third argument:
+Custom readers may require a custom state. You can provide the context to the tokenizer, and it would pass it to all
+readers as a third argument:
 
 ```ts
 import {createTokenizer, Reader} from 'tokenizer-dsl';
 
-const fooReader: Reader = (input, offset, context) => {
+// Define a reader that uses a context
+const fooReader: Reader<{ bar: number }> = (input, offset, context) => {
   console.log(context.bar);
   return -1;
 };
 
+// Compile a tokenizer
 const tokenizer = createTokenizer([
   {reader: fooReader}
 ]);
 
+// Pass the context value
 tokenizer('foobar', handler, {bar: 123});
 ```
 
@@ -769,19 +727,19 @@ Results are in millions of operations per second. The higher number is better.
 
 | | tokenizer-dsl | `RegExp` | |
 | -- | --: | --: | -- |
-| [Usage example](#usage) | 5.35 | 2.54 | |
-| `char(['abc'])` | 88.81 | 58.57 | `/[abc]/y` |
-| `char([['a', 'z']])` | 88.12 | 58.48 | `/[a-z]/y` |
-| `all(char(['abc']))` | 39.73 | 50.07 | `/[abc]*/y` |
-| `all(char(['abc']), {minimumCount: 2})` | 67.13 | 50.28 | `/[abc]{2,}/y` |
-| `all(text('abc'))` | 43.05 | 50.26 | `/(?:abc)*/y` |
-| `or(text('abc'), text('123'))` | 67.32 | 57.19 | `/abc\|123/y` |
-| `seq(text('abc'), text('123'))` | 58.86 | 54.28 | `/abc123/y` |
-| `text('abc')` | 72.82 | 57.15 | `/abc/y` |
-| `text('abc', {caseInsensitive: true})` | 71.17 | 55.03 | `/abc/iy` |
-| `until(char(['abc']))` | 51.55 | 48.67 | `/[abc]/g` |
-| `until(text('abc'))` | 51.00 | 33.06 | `/(?=abc)/g` |
-| `until(text('abc'), {inclusive: true})` | 51.90 | 48.82 | `/abc/g` |
+| [Usage example](#usage) | 5.3 | 2.5 | |
+| `char(['abc'])` | 88.8 | 58.5 | `/[abc]/y` |
+| `char([['a', 'z']])` | 88.1 | 58.4 | `/[a-z]/y` |
+| `all(char(['abc']))` | 39.7 | 50.0 | `/[abc]*/y` |
+| `all(char(['abc']), {minimumCount: 2})` | 67.1 | 50.2 | `/[abc]{2,}/y` |
+| `all(text('abc'))` | 43.0 | 50.2 | `/(?:abc)*/y` |
+| `or(text('abc'), text('123'))` | 67.3 | 57.1 | `/abc\|123/y` |
+| `seq(text('abc'), text('123'))` | 58.8 | 54.2 | `/abc123/y` |
+| `text('abc')` | 72.8 | 57.1 | `/abc/y` |
+| `text('abc', {caseInsensitive: true})` | 71.1 | 55.0 | `/abc/iy` |
+| `until(char(['abc']))` | 51.5 | 48.6 | `/[abc]/g` |
+| `until(text('abc'))` | 51.0 | 33.0 | `/(?=abc)/g` |
+| `until(text('abc'), {inclusive: true})` | 51.9 | 48.8 | `/abc/g` |
 
 Tokenizer performance comes from following implementation aspects:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "codedegen": "^1.0.0"
+        "codedegen": "^1.1.0"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^13.1.3",
@@ -1481,9 +1481,9 @@
       }
     },
     "node_modules/codedegen": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/codedegen/-/codedegen-1.0.0.tgz",
-      "integrity": "sha512-KeuO4amWkRiNriOp/79b1F0AsiBFuRNy9+hSA/HUI0GfCWcRWsTad4bUdRuCBIAB4/IFPc02oCkDU9EWU+72cA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/codedegen/-/codedegen-1.1.0.tgz",
+      "integrity": "sha512-eJNXDM02+/2dUUKiJrsydq5vXIb0RXmTIeNyY9sVn09k60bL7gx6fP4cc5E8gd6V2Y8EjhB4dAyZ+hz5jVvZtA=="
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
@@ -5486,9 +5486,9 @@
       "dev": true
     },
     "codedegen": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/codedegen/-/codedegen-1.0.0.tgz",
-      "integrity": "sha512-KeuO4amWkRiNriOp/79b1F0AsiBFuRNy9+hSA/HUI0GfCWcRWsTad4bUdRuCBIAB4/IFPc02oCkDU9EWU+72cA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/codedegen/-/codedegen-1.1.0.tgz",
+      "integrity": "sha512-eJNXDM02+/2dUUKiJrsydq5vXIb0RXmTIeNyY9sVn09k60bL7gx6fP4cc5E8gd6V2Y8EjhB4dAyZ+hz5jVvZtA=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "codedegen": "^1.0.0"
+    "codedegen": "^1.1.0"
   }
 }

--- a/src/main/createTokenizer.ts
+++ b/src/main/createTokenizer.ts
@@ -6,20 +6,19 @@ import {compileRuleIterator, createRuleTree, Rule, TokenHandler, TokenizerState}
  * @template Type The type of the token emitted by the tokenizer.
  * @template Stage The tokenizer stage type.
  * @template Context The context passed to the tokenizer.
- * @template Error The error that the reader may return.
  */
-export interface Tokenizer<Type = unknown, Stage = void, Context = void, Error = never> {
+export interface Tokenizer<Type = unknown, Stage = void, Context = void> {
 
   /**
    * Reads tokens from the input in a non-streaming fashion. Triggers a {@link TokenHandler.unrecognizedToken} if the
    * input wasn't read in full.
    *
    * @param input The input string to tokenize.
-   * @param handler The callbacks that are invoked when tokens are read from the string, or when an error occurs.
+   * @param handler The callbacks that are invoked when tokens are read from the string.
    * @param context The context that should be passed to readers and stage providers.
    * @returns The result state of the tokenizer.
    */
-  (input: string, handler: TokenHandler<Type, Context, Error>, context: Context): TokenizerState<Stage>;
+  (input: string, handler: TokenHandler<Type, Context>, context: Context): TokenizerState<Stage>;
 
   /**
    * Reads tokens from the chunk in a streaming fashion. Does not trigger a {@link TokenHandler.unrecognizedToken} is
@@ -34,23 +33,23 @@ export interface Tokenizer<Type = unknown, Stage = void, Context = void, Error =
    * ```
    *
    * @param chunk The input chunk to tokenize.
-   * @param handler The callbacks that are invoked when tokens are read from the string, or when an error occurs.
-   * @param state The state returned by the previous {@link Tokenizer.write} call.
+   * @param handler The callbacks that are invoked when tokens are read from the string.
+   * @param state The mutable state returned by the previous {@link Tokenizer.write} call.
    * @param context The context that should be passed to readers and stage providers.
    * @returns The result state of the tokenizer.
    */
-  write(chunk: string, handler: TokenHandler<Type, Context, Error>, state: TokenizerState<Stage> | void, context: Context): TokenizerState<Stage>;
+  write(chunk: string, handler: TokenHandler<Type, Context>, state: TokenizerState<Stage> | void, context: Context): TokenizerState<Stage>;
 
   /**
    * Reads remaining tokens from the {@link TokenizerState.chunk}. Triggers a {@link TokenHandler.unrecognizedToken} if
    * the  {@link TokenizerState.chunk} wasn't read in full.
    *
-   * @param handler The callbacks that are invoked when tokens are read from the string, or when an error occurs.
-   * @param state The state returned by the previous {@link Tokenizer.write} call.
+   * @param handler The callbacks that are invoked when tokens are read from the string.
+   * @param state The mutable state returned by the previous {@link Tokenizer.write} call.
    * @param context The context that should be passed to readers and stage providers.
    * @returns The result state of the tokenizer.
    */
-  end(handler: TokenHandler<Type, Context, Error>, state: TokenizerState<Stage>, context: Context): TokenizerState<Stage>;
+  end(handler: TokenHandler<Type, Context>, state: TokenizerState<Stage>, context: Context): TokenizerState<Stage>;
 }
 
 /**
@@ -60,9 +59,8 @@ export interface Tokenizer<Type = unknown, Stage = void, Context = void, Error =
  *
  * @template Type The type of tokens emitted by the tokenizer.
  * @template Context The context that rules may consume.
- * @template Error The error that the reader may return.
  */
-export function createTokenizer<Type, Context = void, Error = never>(rules: Rule<Type, void, Context, Error>[]): Tokenizer<Type, void, Context, Error>;
+export function createTokenizer<Type, Context = void>(rules: Rule<Type, void, Context>[]): Tokenizer<Type, void, Context>;
 
 /**
  * Creates a new pure tokenizer function.
@@ -73,38 +71,34 @@ export function createTokenizer<Type, Context = void, Error = never>(rules: Rule
  * @template Type The type of tokens emitted by the tokenizer.
  * @template Stage The type of stages at which rules are applied.
  * @template Context The context that rules may consume.
- * @template Error The error that the reader may return.
  */
-export function createTokenizer<Type, Stage, Context = void, Error = never>(rules: Rule<Type, Stage, Context, Error>[], initialStage: Stage): Tokenizer<Type, Stage, Context, Error>;
+export function createTokenizer<Type, Stage, Context = void>(rules: Rule<Type, Stage, Context>[], initialStage: Stage): Tokenizer<Type, Stage, Context>;
 
 export function createTokenizer(rules: Rule[], initialStage?: any) {
   const ruleIterator = compileRuleIterator(createRuleTree(rules));
 
   const tokenizer: Tokenizer = (chunk, handler, context) => {
-    const state = createState(initialStage, chunk, 0, 0);
+    const state: TokenizerState = {stage: initialStage, chunk, chunkOffset: 0, offset: 0};
     ruleIterator(state, handler, context, false);
     return state;
   };
 
   tokenizer.write = (chunk, handler, state, context) => {
     if (state) {
-      state = createState(state.stage, state.chunk.slice(state.offset) + chunk, 0, state.chunkOffset + state.offset);
+      state.chunk = state.chunk.slice(state.offset) + chunk;
+      state.chunkOffset += state.offset;
+      state.offset = 0;
     } else {
-      state = createState(initialStage, chunk, 0, 0);
+      state = {stage: initialStage, chunk, chunkOffset: 0, offset: 0};
     }
     ruleIterator(state, handler, context, true);
     return state;
   };
 
   tokenizer.end = (handler, state, context) => {
-    state = createState(state.stage, state.chunk, state.offset, state.chunkOffset);
     ruleIterator(state, handler, context, false);
     return state;
   };
 
   return tokenizer;
-}
-
-function createState<Stage>(stage: Stage, chunk: string, offset: number, chunkOffset: number): TokenizerState<Stage> {
-  return {stage, chunk, offset, chunkOffset};
 }

--- a/src/main/createTokenizer.ts
+++ b/src/main/createTokenizer.ts
@@ -10,8 +10,7 @@ import {compileRuleIterator, createRuleTree, Rule, TokenHandler, TokenizerState}
 export interface Tokenizer<Type = unknown, Stage = void, Context = void> {
 
   /**
-   * Reads tokens from the input in a non-streaming fashion. Triggers a {@link TokenHandler.unrecognizedToken} if the
-   * input wasn't read in full.
+   * Reads tokens from the input in a non-streaming fashion.
    *
    * @param input The input string to tokenize.
    * @param handler The callbacks that are invoked when tokens are read from the string.
@@ -21,9 +20,8 @@ export interface Tokenizer<Type = unknown, Stage = void, Context = void> {
   (input: string, handler: TokenHandler<Type, Context>, context: Context): TokenizerState<Stage>;
 
   /**
-   * Reads tokens from the chunk in a streaming fashion. Does not trigger a {@link TokenHandler.unrecognizedToken} is
-   * input wasn't read in full. During streaming, {@link TokenHandler.token} is triggered only with confirmed tokens.
-   * Token is confirmed if the consequent token was successfully read.
+   * Reads tokens from the chunk in a streaming fashion. During streaming, {@link TokenHandler} is triggered only with
+   * confirmed tokens. Token is confirmed if the consequent token was successfully read.
    *
    * ```ts
    * let state;
@@ -41,8 +39,7 @@ export interface Tokenizer<Type = unknown, Stage = void, Context = void> {
   write(chunk: string, handler: TokenHandler<Type, Context>, state: TokenizerState<Stage> | void, context: Context): TokenizerState<Stage>;
 
   /**
-   * Reads remaining tokens from the {@link TokenizerState.chunk}. Triggers a {@link TokenHandler.unrecognizedToken} if
-   * the  {@link TokenizerState.chunk} wasn't read in full.
+   * Reads remaining tokens from the {@link TokenizerState.chunk}.
    *
    * @param handler The callbacks that are invoked when tokens are read from the string.
    * @param state The mutable state returned by the previous {@link Tokenizer.write} call.

--- a/src/main/createTokenizer.ts
+++ b/src/main/createTokenizer.ts
@@ -15,19 +15,19 @@ export interface Tokenizer<Type = unknown, Stage = void, Context = void> {
    * @param input The input string to tokenize.
    * @param handler The callbacks that are invoked when tokens are read from the string.
    * @param context The context that should be passed to readers and stage providers.
+   * @param state The mutable state used by the tokenizer.
    * @returns The result state of the tokenizer.
    */
-  (input: string, handler: TokenHandler<Type, Context>, context: Context): TokenizerState<Stage>;
+  (input: string, handler: TokenHandler<Type, Context>, context: Context, state?: TokenizerState<Stage>): TokenizerState<Stage>;
 
   /**
    * Reads tokens from the chunk in a streaming fashion. During streaming, {@link TokenHandler} is triggered only with
    * confirmed tokens. Token is confirmed if the consequent token was successfully read.
    *
    * ```ts
-   * let state;
-   * state = tokenizer.write('foo', handler);
-   * state = tokenizer.write('bar', handler, state);
-   * state = tokenizer.end(handler, state);
+   * let state = tokenizer.write('foo', handler);
+   * tokenizer.write('bar', handler, state);
+   * tokenizer.end(handler, state);
    * ```
    *
    * @param chunk The input chunk to tokenize.

--- a/src/main/readers/all.ts
+++ b/src/main/readers/all.ts
@@ -1,5 +1,5 @@
-import {Binding, Code, CodeBindings, createVar, Var} from 'codedegen';
-import {die, toInteger} from '../utils';
+import {Binding, Code, CodeBindings, Var} from 'codedegen';
+import {createVar, die, toInteger} from '../utils';
 import {never} from './never';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';

--- a/src/main/readers/all.ts
+++ b/src/main/readers/all.ts
@@ -30,7 +30,7 @@ export interface AllOptions {
  *
  * @template Context The context passed by tokenizer.
  */
-export function all<Context = any, Error = never>(reader: Reader<Context, Error>, options: AllOptions = {}): Reader<Context, Error> {
+export function all<Context = any>(reader: Reader<Context>, options: AllOptions = {}): Reader<Context> {
 
   let {
     minimumCount,
@@ -49,9 +49,9 @@ export function all<Context = any, Error = never>(reader: Reader<Context, Error>
   return new AllReader(reader, minimumCount, maximumCount);
 }
 
-export class AllReader<Context, Error> implements ReaderCodegen {
+export class AllReader<Context> implements ReaderCodegen {
 
-  constructor(public reader: Reader<Context, Error>, public minimumCount: number, public maximumCount: number) {
+  constructor(public reader: Reader<Context>, public minimumCount: number, public maximumCount: number) {
   }
 
   factory(inputVar: Var, offsetVar: Var, contextVar: Var, resultVar: Var): CodeBindings {
@@ -65,7 +65,7 @@ export class AllReader<Context, Error> implements ReaderCodegen {
       resultVar, '=', minimumCount > 0 ? NO_MATCH : offsetVar, ';',
       'var ',
       minimumCount > 1 ? [indexVar, '=', offsetVar, ','] : '',
-      readerResultVar, ';',
+      readerResultVar, minimumCount === 0 && maximumCount === 0 ? ['=', offsetVar] : '', ';',
     ];
 
     const count = Math.max(minimumCount, maximumCount);
@@ -75,20 +75,17 @@ export class AllReader<Context, Error> implements ReaderCodegen {
 
       code.push(
           createReaderCallCode(reader, inputVar, i === 0 ? offsetVar : nextOffsetVar, contextVar, readerResultVar, bindings),
-          'if(typeof ', readerResultVar, '!=="number"){', resultVar, '=', readerResultVar, '}else ',
           'if(', readerResultVar, '>', i === 0 ? offsetVar : nextOffsetVar, '){',
-          nextOffsetVar, '=', readerResultVar, ';',
+          maximumCount === 0 && i === count - 1 ? '' : [nextOffsetVar, '=', readerResultVar, ';'],
       );
     }
 
     if (maximumCount === 0) {
       code.push(
           'do{',
-          createReaderCallCode(reader, inputVar, resultVar, contextVar, readerResultVar, bindings),
-          'if(typeof ', readerResultVar, '!=="number"){', resultVar, '=', readerResultVar, ';break}',
-          'if(', readerResultVar, '<=', resultVar, ')break;',
           resultVar, '=', readerResultVar, ';',
-          '}while(true)',
+          createReaderCallCode(reader, inputVar, resultVar, contextVar, readerResultVar, bindings),
+          '}while(', readerResultVar, '>', resultVar, ')',
       );
     }
 

--- a/src/main/readers/all.ts
+++ b/src/main/readers/all.ts
@@ -3,7 +3,7 @@ import {createVar, die, toInteger} from '../utils';
 import {never} from './never';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';
-import {createCodeBindings, createReaderCallCode, NO_MATCH} from './reader-utils';
+import {createCodeBindings, createReaderCallCode} from './reader-utils';
 
 export interface AllOptions {
 
@@ -62,7 +62,7 @@ export class AllReader<Context> implements ReaderCodegen {
     const bindings: Binding[] = [];
 
     const code: Code[] = [
-      resultVar, '=', minimumCount > 0 ? NO_MATCH : offsetVar, ';',
+      resultVar, '=', minimumCount > 0 ? '-1' : offsetVar, ';',
       'var ',
       minimumCount > 1 ? [indexVar, '=', offsetVar, ','] : '',
       readerResultVar, minimumCount === 0 && maximumCount === 0 ? ['=', offsetVar] : '', ';',

--- a/src/main/readers/char.ts
+++ b/src/main/readers/char.ts
@@ -50,7 +50,7 @@ export class CharCodeRangeReader implements ReaderCodegen {
       resultVar, '=',
       offsetVar, '<', inputVar, '.length&&(',
       charCodeVar, '=', inputVar, '.charCodeAt(', offsetVar, '),',
-      createCharPredicateCode(charCodeVar, this.charCodeRanges), ')?', offsetVar, '+1:', NO_MATCH, ';',
+      createCharPredicateCode(charCodeVar, this.charCodeRanges), ')?', offsetVar, '+1:' + NO_MATCH + ';',
     ]);
   }
 }

--- a/src/main/readers/char.ts
+++ b/src/main/readers/char.ts
@@ -1,5 +1,5 @@
-import {Code, CodeBindings, createVar, Var} from 'codedegen';
-import {die} from '../utils';
+import {Code, CodeBindings, Var} from 'codedegen';
+import {createVar, die} from '../utils';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';
 import {createCodeBindings, NO_MATCH, toCharCodes} from './reader-utils';

--- a/src/main/readers/char.ts
+++ b/src/main/readers/char.ts
@@ -2,7 +2,7 @@ import {Code, CodeBindings, Var} from 'codedegen';
 import {createVar, die} from '../utils';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';
-import {createCodeBindings, NO_MATCH, toCharCodes} from './reader-utils';
+import {createCodeBindings, toCharCodes} from './reader-utils';
 
 export type CharRange = string | number | [number | string, number | string];
 
@@ -50,7 +50,7 @@ export class CharCodeRangeReader implements ReaderCodegen {
       resultVar, '=',
       offsetVar, '<', inputVar, '.length&&(',
       charCodeVar, '=', inputVar, '.charCodeAt(', offsetVar, '),',
-      createCharPredicateCode(charCodeVar, this.charCodeRanges), ')?', offsetVar, '+1:' + NO_MATCH + ';',
+      createCharPredicateCode(charCodeVar, this.charCodeRanges), ')?', offsetVar, '+1:-1;',
     ]);
   }
 }

--- a/src/main/readers/char.ts
+++ b/src/main/readers/char.ts
@@ -16,7 +16,7 @@ export type CharCodeRange = number | [number, number];
  *
  * @see {@link text}
  */
-export function char(chars: CharRange[]): Reader<any, any> {
+export function char(chars: CharRange[]): Reader<any> {
   const charCodeRanges: CharCodeRange[] = [];
 
   for (const range of chars) {

--- a/src/main/readers/end.ts
+++ b/src/main/readers/end.ts
@@ -9,7 +9,7 @@ import {createCodeBindings} from './reader-utils';
  *
  * @see {@link skip}
  */
-export function end(offset = 0): Reader<any, any> {
+export function end(offset = 0): Reader<any> {
   return new EndReader(offset | 0);
 }
 

--- a/src/main/readers/lookahead.ts
+++ b/src/main/readers/lookahead.ts
@@ -2,7 +2,7 @@ import {Binding, CodeBindings, Var} from 'codedegen';
 import {never} from './never';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';
-import {createCodeBindings, createReaderCallCode, NO_MATCH} from './reader-utils';
+import {createCodeBindings, createReaderCallCode} from './reader-utils';
 
 /**
  * Creates a reader that returns the current offset if the reader matches.
@@ -26,7 +26,7 @@ export class LookaheadReader<Context> implements ReaderCodegen {
     return createCodeBindings(
         [
           createReaderCallCode(this.reader, inputVar, offsetVar, contextVar, resultVar, bindings),
-          resultVar, '=', resultVar, '<', offsetVar, '?' + NO_MATCH + ':', offsetVar, ';',
+          resultVar, '=', resultVar, '<', offsetVar, '?-1:', offsetVar, ';',
         ],
         bindings,
     );

--- a/src/main/readers/lookahead.ts
+++ b/src/main/readers/lookahead.ts
@@ -8,16 +8,16 @@ import {createCodeBindings, createReaderCallCode, NO_MATCH} from './reader-utils
 /**
  * Creates a reader that returns the current offset if the reader matches.
  */
-export function lookahead<Context = any, Error = never>(reader: Reader<Context, Error>): Reader<Context, Error> {
+export function lookahead<Context = any>(reader: Reader<Context>): Reader<Context> {
   if (reader === none || reader === never) {
     return reader;
   }
   return new LookaheadReader(reader);
 }
 
-export class LookaheadReader<Context, Error> implements ReaderCodegen {
+export class LookaheadReader<Context> implements ReaderCodegen {
 
-  constructor(public reader: Reader<Context, Error>) {
+  constructor(public reader: Reader<Context>) {
   }
 
   factory(inputVar: Var, offsetVar: Var, contextVar: Var, resultVar: Var): CodeBindings {
@@ -29,7 +29,7 @@ export class LookaheadReader<Context, Error> implements ReaderCodegen {
         [
           'var ', readerResultVar, ';',
           createReaderCallCode(this.reader, inputVar, offsetVar, contextVar, readerResultVar, bindings),
-          resultVar, '=typeof ', readerResultVar, '!=="number"||', readerResultVar, '<', offsetVar, '?', NO_MATCH, ':', offsetVar, ';',
+          resultVar, '=', readerResultVar, '<', offsetVar, '?', NO_MATCH, ':', offsetVar, ';',
         ],
         bindings,
     );

--- a/src/main/readers/lookahead.ts
+++ b/src/main/readers/lookahead.ts
@@ -1,5 +1,4 @@
 import {Binding, CodeBindings, Var} from 'codedegen';
-import {createVar} from '../utils';
 import {never} from './never';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';
@@ -22,14 +21,12 @@ export class LookaheadReader<Context> implements ReaderCodegen {
 
   factory(inputVar: Var, offsetVar: Var, contextVar: Var, resultVar: Var): CodeBindings {
 
-    const readerResultVar = createVar();
     const bindings: Binding[] = [];
 
     return createCodeBindings(
         [
-          'var ', readerResultVar, ';',
-          createReaderCallCode(this.reader, inputVar, offsetVar, contextVar, readerResultVar, bindings),
-          resultVar, '=', readerResultVar, '<', offsetVar, '?', NO_MATCH, ':', offsetVar, ';',
+          createReaderCallCode(this.reader, inputVar, offsetVar, contextVar, resultVar, bindings),
+          resultVar, '=', resultVar, '<', offsetVar, '?' + NO_MATCH + ':', offsetVar, ';',
         ],
         bindings,
     );

--- a/src/main/readers/lookahead.ts
+++ b/src/main/readers/lookahead.ts
@@ -1,4 +1,5 @@
-import {Binding, CodeBindings, createVar, Var} from 'codedegen';
+import {Binding, CodeBindings, Var} from 'codedegen';
+import {createVar} from '../utils';
 import {never} from './never';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';

--- a/src/main/readers/maybe.ts
+++ b/src/main/readers/maybe.ts
@@ -12,16 +12,16 @@ import {createCodeBindings, createReaderCallCode} from './reader-utils';
  *
  * @template Context The context passed by tokenizer.
  */
-export function maybe<Context = any, Error = never>(reader: Reader<Context, Error>): Reader<Context, Error> {
+export function maybe<Context = any>(reader: Reader<Context>): Reader<Context> {
   if (reader === none || reader === never) {
     return none;
   }
   return new MaybeReader(reader);
 }
 
-export class MaybeReader<Context, Error> implements ReaderCodegen {
+export class MaybeReader<Context> implements ReaderCodegen {
 
-  constructor(public reader: Reader<Context, Error>) {
+  constructor(public reader: Reader<Context>) {
   }
 
   factory(inputVar: Var, offsetVar: Var, contextVar: Var, resultVar: Var): CodeBindings {
@@ -33,7 +33,7 @@ export class MaybeReader<Context, Error> implements ReaderCodegen {
         [
           'var ', readerResultVar, ';',
           createReaderCallCode(this.reader, inputVar, offsetVar, contextVar, readerResultVar, bindings),
-          resultVar, '=typeof ', readerResultVar, '==="number"&&', readerResultVar, '<', offsetVar, '?', offsetVar, ':', readerResultVar, ';',
+          resultVar, '=', readerResultVar, '<', offsetVar, '?', offsetVar, ':', readerResultVar, ';',
         ],
         bindings,
     );

--- a/src/main/readers/maybe.ts
+++ b/src/main/readers/maybe.ts
@@ -1,4 +1,5 @@
-import {Binding, CodeBindings, createVar, Var} from 'codedegen';
+import {Binding, CodeBindings, Var} from 'codedegen';
+import {createVar} from '../utils';
 import {never} from './never';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';

--- a/src/main/readers/maybe.ts
+++ b/src/main/readers/maybe.ts
@@ -1,5 +1,4 @@
 import {Binding, CodeBindings, Var} from 'codedegen';
-import {createVar} from '../utils';
 import {never} from './never';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';
@@ -26,14 +25,12 @@ export class MaybeReader<Context> implements ReaderCodegen {
 
   factory(inputVar: Var, offsetVar: Var, contextVar: Var, resultVar: Var): CodeBindings {
 
-    const readerResultVar = createVar();
     const bindings: Binding[] = [];
 
     return createCodeBindings(
         [
-          'var ', readerResultVar, ';',
-          createReaderCallCode(this.reader, inputVar, offsetVar, contextVar, readerResultVar, bindings),
-          resultVar, '=', readerResultVar, '<', offsetVar, '?', offsetVar, ':', readerResultVar, ';',
+          createReaderCallCode(this.reader, inputVar, offsetVar, contextVar, resultVar, bindings),
+          'if(', resultVar, '<', offsetVar, ')', resultVar, '=', offsetVar, ';',
         ],
         bindings,
     );

--- a/src/main/readers/never.ts
+++ b/src/main/readers/never.ts
@@ -8,7 +8,7 @@ export const never: Reader<any> = {
 
   factory(inputVar, offsetVar, contextVar, resultVar) {
     return createCodeBindings([
-      resultVar, '=', NO_MATCH, ';',
+      resultVar, '=' + NO_MATCH + ';',
     ]);
   }
 };

--- a/src/main/readers/never.ts
+++ b/src/main/readers/never.ts
@@ -4,7 +4,7 @@ import {createCodeBindings, NO_MATCH} from './reader-utils';
 /**
  * The singleton reader that always returns -1.
  */
-export const never: Reader<any, any> = {
+export const never: Reader<any> = {
 
   factory(inputVar, offsetVar, contextVar, resultVar) {
     return createCodeBindings([

--- a/src/main/readers/never.ts
+++ b/src/main/readers/never.ts
@@ -1,5 +1,5 @@
 import {Reader} from './reader-types';
-import {createCodeBindings, NO_MATCH} from './reader-utils';
+import {createCodeBindings} from './reader-utils';
 
 /**
  * The singleton reader that always returns -1.
@@ -8,7 +8,7 @@ export const never: Reader<any> = {
 
   factory(inputVar, offsetVar, contextVar, resultVar) {
     return createCodeBindings([
-      resultVar, '=' + NO_MATCH + ';',
+      resultVar, '=-1;',
     ]);
   }
 };

--- a/src/main/readers/none.ts
+++ b/src/main/readers/none.ts
@@ -7,7 +7,7 @@ import {createCodeBindings} from './reader-utils';
  * @see {@link skip}
  * @see {@link end}
  */
-export const none: Reader<any, any> = {
+export const none: Reader<any> = {
 
   factory(inputVar, offsetVar, contextVar, resultVar) {
     return createCodeBindings([

--- a/src/main/readers/or.ts
+++ b/src/main/readers/or.ts
@@ -11,9 +11,9 @@ import {createCodeBindings, createReaderCallCode} from './reader-utils';
  *
  * @template Context The context passed by tokenizer.
  */
-export function or<Context = any, Error = never>(...readers: Reader<Context, Error>[]): Reader<Context, Error> {
+export function or<Context = any>(...readers: Reader<Context>[]): Reader<Context> {
 
-  const children: Reader<Context, Error>[] = [];
+  const children: Reader<Context>[] = [];
 
   for (const reader of readers) {
     if (reader === none) {
@@ -37,9 +37,9 @@ export function or<Context = any, Error = never>(...readers: Reader<Context, Err
   return new OrReader(children);
 }
 
-export class OrReader<Context, Error> implements ReaderCodegen {
+export class OrReader<Context> implements ReaderCodegen {
 
-  constructor(public readers: Reader<Context, Error>[]) {
+  constructor(public readers: Reader<Context>[]) {
   }
 
   factory(inputVar: Var, offsetVar: Var, contextVar: Var, resultVar: Var): CodeBindings {
@@ -50,12 +50,10 @@ export class OrReader<Context, Error> implements ReaderCodegen {
     const bindings: Binding[] = [];
 
     for (let i = 0; i < readersLength; ++i) {
-      const reader = readers[i];
-
-      code.push(createReaderCallCode(reader, inputVar, offsetVar, contextVar, resultVar, bindings));
-      if (i < readersLength - 1) {
-        code.push('if(typeof ', resultVar, '==="number"&&', resultVar, '<', offsetVar, '){');
-      }
+      code.push(
+          createReaderCallCode(readers[i], inputVar, offsetVar, contextVar, resultVar, bindings),
+          i < readersLength - 1 ? ['if(', resultVar, '<', offsetVar, '){'] : '',
+      );
     }
     code.push('}'.repeat(readersLength - 1));
 

--- a/src/main/readers/or.ts
+++ b/src/main/readers/or.ts
@@ -46,14 +46,15 @@ export class OrReader<Context> implements ReaderCodegen {
     const {readers} = this;
 
     const readersLength = readers.length;
-    const code: Code[] = [];
     const bindings: Binding[] = [];
+    const code: Code[] = [];
 
     for (let i = 0; i < readersLength; ++i) {
-      code.push(
-          createReaderCallCode(readers[i], inputVar, offsetVar, contextVar, resultVar, bindings),
-          i < readersLength - 1 ? ['if(', resultVar, '<', offsetVar, '){'] : '',
-      );
+      code.push(createReaderCallCode(readers[i], inputVar, offsetVar, contextVar, resultVar, bindings));
+
+      if (i < readersLength - 1) {
+        code.push('if(', resultVar, '<', offsetVar, '){');
+      }
     }
     code.push('}'.repeat(readersLength - 1));
 

--- a/src/main/readers/reader-types.ts
+++ b/src/main/readers/reader-types.ts
@@ -14,7 +14,7 @@ export type Reader<Context = void> = ReaderFunction<Context> | ReaderCodegen;
  *
  * ```ts
  * const abcReader: Reader = (input, offset) => {
- *   return input.startsWith('abc', offset) ? offset + 3 : NO_MATCH;
+ *   return input.startsWith('abc', offset) ? offset + 3 : -1;
  * };
  * ```
  *

--- a/src/main/readers/reader-types.ts
+++ b/src/main/readers/reader-types.ts
@@ -4,9 +4,8 @@ import {CodeBindings, Var} from 'codedegen';
  * The reader definition that can be compiled into a function that reads chars from the input string.
  *
  * @template Context The context passed by tokenizer.
- * @template Error The error that the reader may return.
  */
-export type Reader<Context = void, Error = never> = ReaderFunction<Context, Error> | ReaderCodegen;
+export type Reader<Context = void> = ReaderFunction<Context> | ReaderCodegen;
 
 /**
  * Takes the string `input` and the offset in this string `offset` and returns the next offset that is greater or equal
@@ -20,9 +19,8 @@ export type Reader<Context = void, Error = never> = ReaderFunction<Context, Erro
  * ```
  *
  * @template Context The context passed by tokenizer.
- * @template Error The error that the reader may return.
  */
-export type ReaderFunction<Context = void, Error = never> = (input: string, offset: number, context: Context) => Error | number;
+export type ReaderFunction<Context = void> = (input: string, offset: number, context: Context) => number;
 
 /**
  * Factory that returns the reader code and values for variables that must be bound to the reader.

--- a/src/main/readers/reader-types.ts
+++ b/src/main/readers/reader-types.ts
@@ -35,7 +35,7 @@ export interface ReaderCodegen {
    * const abcReaderCodegenFactory: ReaderCodegenFactory = (inputVar, offsetVar, contextVar, resultVar) => {
    *   const abcVar = Symbol();
    *   return {
-   *     code: [resultVar, '=', inputVar, '.startsWith(', abcVar, ',', offsetVar, ')?', offsetVar, '+3:', NO_MATCH, ';'],
+   *     code: [resultVar, '=', inputVar, '.startsWith(', abcVar, ',', offsetVar, ')?', offsetVar, '+3:-1;'],
    *     bindings: [[abcVar, 'abc']],
    *   };
    * };

--- a/src/main/readers/reader-utils.ts
+++ b/src/main/readers/reader-utils.ts
@@ -1,4 +1,5 @@
-import {Binding, Code, CodeBindings, compileFunction, createVar, Var} from 'codedegen';
+import {Binding, Code, CodeBindings, compileFunction, Var} from 'codedegen';
+import {createVar} from '../utils';
 import {Reader, ReaderFunction} from './reader-types';
 
 /**

--- a/src/main/readers/reader-utils.ts
+++ b/src/main/readers/reader-utils.ts
@@ -22,7 +22,7 @@ export function createReaderCallCode<Context>(reader: Reader<Context>, inputVar:
     const readerVar = createVar();
     bindings.push([readerVar, reader]);
 
-    return [resultVar, '=', readerVar, '(', inputVar, ',', offsetVar, ',', contextVar, ')', ';'];
+    return [resultVar, '=', readerVar, '(', inputVar, ',', offsetVar, ',', contextVar, ');'];
   }
 
   const codeBindings = reader.factory(inputVar, offsetVar, contextVar, resultVar);

--- a/src/main/readers/reader-utils.ts
+++ b/src/main/readers/reader-utils.ts
@@ -16,7 +16,7 @@ export function toCharCodes(str: string): number[] {
   return charCodes;
 }
 
-export function createReaderCallCode<Context, Error>(reader: Reader<Context, Error>, inputVar: Var, offsetVar: Var, contextVar: Var, resultVar: Var, bindings: Binding[]): Code {
+export function createReaderCallCode<Context>(reader: Reader<Context>, inputVar: Var, offsetVar: Var, contextVar: Var, resultVar: Var, bindings: Binding[]): Code {
 
   if (typeof reader === 'function') {
     const readerVar = createVar();
@@ -44,7 +44,7 @@ export function createCodeBindings(code: Code, bindings?: Binding[]): CodeBindin
  *
  * @template Context The context passed by tokenizer.
  */
-export function toReaderFunction<Context = void, Error = never>(reader: Reader<Context, Error>): ReaderFunction<Context, Error> {
+export function toReaderFunction<Context = void>(reader: Reader<Context>): ReaderFunction<Context> {
 
   if (typeof reader === 'function') {
     return reader;

--- a/src/main/readers/reader-utils.ts
+++ b/src/main/readers/reader-utils.ts
@@ -2,11 +2,6 @@ import {Binding, Code, CodeBindings, compileFunction, Var} from 'codedegen';
 import {createVar} from '../utils';
 import {Reader, ReaderFunction} from './reader-types';
 
-/**
- * OK code returned from a reader that means that it didn't match any chars.
- */
-export const NO_MATCH = -1;
-
 export function toCharCodes(str: string): number[] {
   const charCodes: number[] = [];
 

--- a/src/main/readers/regex.ts
+++ b/src/main/readers/regex.ts
@@ -1,4 +1,5 @@
-import {CodeBindings, createVar, Var} from 'codedegen';
+import {CodeBindings, Var} from 'codedegen';
+import {createVar} from '../utils';
 import {Reader, ReaderCodegen} from './reader-types';
 import {createCodeBindings, NO_MATCH} from './reader-utils';
 

--- a/src/main/readers/regex.ts
+++ b/src/main/readers/regex.ts
@@ -27,7 +27,7 @@ export class RegexReader implements ReaderCodegen {
     return createCodeBindings(
         [
           reVar, '.lastIndex=', offsetVar, ';',
-          resultVar, '=', reVar, '.test(', inputVar, ')?', reVar, '.lastIndex:', NO_MATCH, ';',
+          resultVar, '=', reVar, '.test(', inputVar, ')?', reVar, '.lastIndex:' + NO_MATCH + ';',
         ],
         [[reVar, this.re]],
     );

--- a/src/main/readers/regex.ts
+++ b/src/main/readers/regex.ts
@@ -8,7 +8,7 @@ import {createCodeBindings, NO_MATCH} from './reader-utils';
  *
  * @param re The `RegExp` to match.
  */
-export function regex(re: RegExp): Reader<any, any> {
+export function regex(re: RegExp): Reader<any> {
   return new RegexReader(re);
 }
 

--- a/src/main/readers/regex.ts
+++ b/src/main/readers/regex.ts
@@ -1,7 +1,7 @@
 import {CodeBindings, Var} from 'codedegen';
 import {createVar} from '../utils';
 import {Reader, ReaderCodegen} from './reader-types';
-import {createCodeBindings, NO_MATCH} from './reader-utils';
+import {createCodeBindings} from './reader-utils';
 
 /**
  * Creates a reader that matches a substring.
@@ -27,7 +27,7 @@ export class RegexReader implements ReaderCodegen {
     return createCodeBindings(
         [
           reVar, '.lastIndex=', offsetVar, ';',
-          resultVar, '=', reVar, '.test(', inputVar, ')?', reVar, '.lastIndex:' + NO_MATCH + ';',
+          resultVar, '=', reVar, '.test(', inputVar, ')?', reVar, '.lastIndex:-1;',
         ],
         [[reVar, this.re]],
     );

--- a/src/main/readers/seq.ts
+++ b/src/main/readers/seq.ts
@@ -1,4 +1,5 @@
-import {Binding, Code, CodeBindings, createVar, Var} from 'codedegen';
+import {Binding, Code, CodeBindings, Var} from 'codedegen';
+import {createVar} from '../utils';
 import {never} from './never';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';

--- a/src/main/readers/seq.ts
+++ b/src/main/readers/seq.ts
@@ -3,7 +3,7 @@ import {createVar} from '../utils';
 import {never} from './never';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';
-import {createCodeBindings, createReaderCallCode, NO_MATCH} from './reader-utils';
+import {createCodeBindings, createReaderCallCode} from './reader-utils';
 
 /**
  * Creates a reader that applies readers one after another.
@@ -52,7 +52,7 @@ export class SeqReader<Context> implements ReaderCodegen {
     const readersLength = readers.length;
     const bindings: Binding[] = [];
     const code: Code[] = [
-      resultVar, '=' + NO_MATCH + ';',
+      resultVar, '=-1;',
 
       'var ',
       indexVar, '=', offsetVar, ',',

--- a/src/main/readers/seq.ts
+++ b/src/main/readers/seq.ts
@@ -46,13 +46,13 @@ export class SeqReader<Context> implements ReaderCodegen {
   factory(inputVar: Var, offsetVar: Var, contextVar: Var, resultVar: Var): CodeBindings {
     const {readers} = this;
 
-    const readerResultVar = createVar();
     const indexVar = createVar();
+    const readerResultVar = createVar();
 
     const readersLength = readers.length;
     const bindings: Binding[] = [];
     const code: Code[] = [
-      resultVar, '=', NO_MATCH, ';',
+      resultVar, '=' + NO_MATCH + ';',
 
       'var ',
       indexVar, '=', offsetVar, ',',
@@ -63,7 +63,7 @@ export class SeqReader<Context> implements ReaderCodegen {
       code.push(
           createReaderCallCode(readers[i], inputVar, indexVar, contextVar, readerResultVar, bindings),
           'if(', readerResultVar, '>=', indexVar, '){',
-          i === readersLength - 1 ? resultVar : indexVar, '=', readerResultVar, ';',
+          i < readersLength - 1 ? indexVar : resultVar, '=', readerResultVar, ';',
       );
     }
 

--- a/src/main/readers/seq.ts
+++ b/src/main/readers/seq.ts
@@ -12,9 +12,9 @@ import {createCodeBindings, createReaderCallCode, NO_MATCH} from './reader-utils
  *
  * @template Context The context passed by tokenizer.
  */
-export function seq<Context = any, Error = never>(...readers: Reader<Context, Error>[]): Reader<Context, Error> {
+export function seq<Context = any>(...readers: Reader<Context>[]): Reader<Context> {
 
-  const children: Reader<Context, Error>[] = [];
+  const children: Reader<Context>[] = [];
 
   for (const reader of readers) {
     if (reader instanceof SeqReader) {
@@ -38,36 +38,37 @@ export function seq<Context = any, Error = never>(...readers: Reader<Context, Er
   return new SeqReader(children);
 }
 
-export class SeqReader<Context, Error> implements ReaderCodegen {
+export class SeqReader<Context> implements ReaderCodegen {
 
-  constructor(public readers: Reader<Context, Error>[]) {
+  constructor(public readers: Reader<Context>[]) {
   }
 
   factory(inputVar: Var, offsetVar: Var, contextVar: Var, resultVar: Var): CodeBindings {
     const {readers} = this;
 
+    const readerResultVar = createVar();
+    const indexVar = createVar();
+
     const readersLength = readers.length;
-    const code: Code[] = [];
     const bindings: Binding[] = [];
+    const code: Code[] = [
+      resultVar, '=', NO_MATCH, ';',
 
-    for (let i = 0; i < readersLength - 1; ++i) {
-      const reader = readers[i];
-      const readerResultVar = createVar();
+      'var ',
+      indexVar, '=', offsetVar, ',',
+      readerResultVar, ';',
+    ];
 
+    for (let i = 0; i < readersLength; ++i) {
       code.push(
-          'var ', readerResultVar, ';',
-          createReaderCallCode(reader, inputVar, offsetVar, contextVar, readerResultVar, bindings),
-          'if(typeof ', readerResultVar, '!=="number")', resultVar, '=', readerResultVar, ';else ',
-          'if(', readerResultVar, '<', offsetVar, ')', resultVar, '=', NO_MATCH, ';else{'
+          createReaderCallCode(readers[i], inputVar, indexVar, contextVar, readerResultVar, bindings),
+          'if(', readerResultVar, '>=', indexVar, '){',
+          i === readersLength - 1 ? resultVar : indexVar, '=', readerResultVar, ';',
       );
-
-      offsetVar = readerResultVar;
     }
 
-    code.push(
-        createReaderCallCode(readers[readersLength - 1], inputVar, offsetVar, contextVar, resultVar, bindings),
-        '}'.repeat(readersLength - 1),
-    );
+    code.push('}'.repeat(readersLength));
+
     return createCodeBindings(code, bindings);
   }
 }

--- a/src/main/readers/skip.ts
+++ b/src/main/readers/skip.ts
@@ -10,7 +10,7 @@ import {createCodeBindings, NO_MATCH} from './reader-utils';
  *
  * @see {@link end}
  */
-export function skip(charCount: number): Reader<any, any> {
+export function skip(charCount: number): Reader<any> {
   return new SkipReader(toInteger(charCount));
 }
 

--- a/src/main/readers/skip.ts
+++ b/src/main/readers/skip.ts
@@ -1,7 +1,7 @@
 import {CodeBindings, Var} from 'codedegen';
 import {toInteger} from '../utils';
 import {Reader, ReaderCodegen} from './reader-types';
-import {createCodeBindings, NO_MATCH} from './reader-utils';
+import {createCodeBindings} from './reader-utils';
 
 /**
  * Creates a reader that skips given number of chars.
@@ -23,7 +23,7 @@ export class SkipReader implements ReaderCodegen {
     const {charCount} = this;
 
     return createCodeBindings([
-      resultVar, '=', offsetVar, '+', charCount, '<=', inputVar, '.length?', offsetVar, '+', charCount, ':' + NO_MATCH + ';',
+      resultVar, '=', offsetVar, '+', charCount, '<=', inputVar, '.length?', offsetVar, '+', charCount, ':-1;',
     ]);
   }
 }

--- a/src/main/readers/skip.ts
+++ b/src/main/readers/skip.ts
@@ -23,7 +23,7 @@ export class SkipReader implements ReaderCodegen {
     const {charCount} = this;
 
     return createCodeBindings([
-      resultVar, '=', offsetVar, '+', charCount, '<=', inputVar, '.length?', offsetVar, '+', charCount, ':', NO_MATCH, ';',
+      resultVar, '=', offsetVar, '+', charCount, '<=', inputVar, '.length?', offsetVar, '+', charCount, ':' + NO_MATCH + ';',
     ]);
   }
 }

--- a/src/main/readers/text.ts
+++ b/src/main/readers/text.ts
@@ -1,5 +1,5 @@
-import {Code, CodeBindings, createVar, Var} from 'codedegen';
-import {die} from '../utils';
+import {Code, CodeBindings, Var} from 'codedegen';
+import {createVar, die} from '../utils';
 import {CharCodeRangeReader} from './char';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';

--- a/src/main/readers/text.ts
+++ b/src/main/readers/text.ts
@@ -23,7 +23,7 @@ export interface TextOptions {
  *
  * @see {@link char}
  */
-export function text(str: string, options: TextOptions = {}): Reader<any, any> {
+export function text(str: string, options: TextOptions = {}): Reader<any> {
 
   const {caseInsensitive} = options;
 

--- a/src/main/readers/text.ts
+++ b/src/main/readers/text.ts
@@ -3,7 +3,7 @@ import {createVar, die} from '../utils';
 import {CharCodeRangeReader} from './char';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';
-import {createCodeBindings, NO_MATCH, toCharCodes} from './reader-utils';
+import {createCodeBindings, toCharCodes} from './reader-utils';
 
 export interface TextOptions {
 
@@ -60,7 +60,7 @@ export class CaseSensitiveTextReader implements ReaderCodegen {
         [
           resultVar, '=', offsetVar, '+', str.length, '<=', inputVar, '.length',
           toCharCodes(str).map((charCode, i) => ['&&', inputVar, '.charCodeAt(', offsetVar, '+', i, ')===', charCode]),
-          '?', offsetVar, '+', str.length, ':' + NO_MATCH + ';',
+          '?', offsetVar, '+', str.length, ':-1;',
         ],
         [[strVar, str]],
     );
@@ -103,7 +103,7 @@ export class CaseInsensitiveTextReader implements ReaderCodegen {
         );
       }
     }
-    code.push('?', offsetVar, '+', charCount, ':' + NO_MATCH + ';');
+    code.push('?', offsetVar, '+', charCount, ':-1;');
 
     return createCodeBindings(code);
   }

--- a/src/main/readers/text.ts
+++ b/src/main/readers/text.ts
@@ -60,7 +60,7 @@ export class CaseSensitiveTextReader implements ReaderCodegen {
         [
           resultVar, '=', offsetVar, '+', str.length, '<=', inputVar, '.length',
           toCharCodes(str).map((charCode, i) => ['&&', inputVar, '.charCodeAt(', offsetVar, '+', i, ')===', charCode]),
-          '?', offsetVar, '+', str.length, ':', NO_MATCH, ';',
+          '?', offsetVar, '+', str.length, ':' + NO_MATCH + ';',
         ],
         [[strVar, str]],
     );
@@ -103,7 +103,7 @@ export class CaseInsensitiveTextReader implements ReaderCodegen {
         );
       }
     }
-    code.push('?', offsetVar, '+', charCount, ':', NO_MATCH, ';');
+    code.push('?', offsetVar, '+', charCount, ':' + NO_MATCH + ';');
 
     return createCodeBindings(code);
   }

--- a/src/main/readers/until.ts
+++ b/src/main/readers/until.ts
@@ -1,4 +1,5 @@
-import {Binding, CodeBindings, createVar, Var} from 'codedegen';
+import {Binding, CodeBindings, Var} from 'codedegen';
+import {createVar} from '../utils';
 import {CharCodeRange, CharCodeRangeReader, createCharPredicateCode} from './char';
 import {never} from './never';
 import {none} from './none';

--- a/src/main/readers/until.ts
+++ b/src/main/readers/until.ts
@@ -58,7 +58,7 @@ export class UntilCharCodeRangeReader implements ReaderCodegen {
     const charCodeVar = createVar();
 
     return createCodeBindings([
-      resultVar, '=', NO_MATCH, ';',
+      resultVar, '=' + NO_MATCH + ';',
 
       'var ',
       inputLengthVar, '=', inputVar, '.length,',
@@ -89,7 +89,7 @@ export class UntilCaseSensitiveTextReader implements ReaderCodegen {
     return createCodeBindings(
         [
           'var ', indexVar, '=', inputVar, '.indexOf(', strVar, ',', offsetVar, ');',
-          resultVar, '=', indexVar, this.inclusive ? ['===-1?', NO_MATCH, ':', indexVar, '+', str.length] : '', ';',
+          resultVar, '=', indexVar, this.inclusive ? ['===-1?' + NO_MATCH + ':', indexVar, '+', str.length] : '', ';',
         ],
         [[strVar, str]],
     );
@@ -109,7 +109,7 @@ export class UntilReader<Context> implements ReaderCodegen {
 
     return createCodeBindings(
         [
-          resultVar, '=', NO_MATCH, ';',
+          resultVar, '=' + NO_MATCH + ';',
 
           'var ',
           indexVar, '=', offsetVar, ',',

--- a/src/main/readers/until.ts
+++ b/src/main/readers/until.ts
@@ -25,7 +25,7 @@ export interface UntilOptions {
  *
  * @template Context The context passed by tokenizer.
  */
-export function until<Context = any, Error = never>(reader: Reader<Context, Error>, options: UntilOptions = {}): Reader<Context, Error> {
+export function until<Context = any>(reader: Reader<Context>, options: UntilOptions = {}): Reader<Context> {
 
   const {inclusive = false} = options;
 
@@ -96,9 +96,9 @@ export class UntilCaseSensitiveTextReader implements ReaderCodegen {
   }
 }
 
-export class UntilReader<Context, Error> implements ReaderCodegen {
+export class UntilReader<Context> implements ReaderCodegen {
 
-  constructor(public reader: Reader<Context, Error>, public inclusive: boolean) {
+  constructor(public reader: Reader<Context>, public inclusive: boolean) {
   }
 
   factory(inputVar: Var, offsetVar: Var, contextVar: Var, resultVar: Var): CodeBindings {
@@ -117,7 +117,6 @@ export class UntilReader<Context, Error> implements ReaderCodegen {
 
           'do{',
           createReaderCallCode(this.reader, inputVar, indexVar, contextVar, readerResultVar, bindings),
-          'if(typeof ', readerResultVar, '!=="number"){', resultVar, '=', readerResultVar, ';break}',
           'if(', readerResultVar, '>=', indexVar, '){', resultVar, '=', this.inclusive ? readerResultVar : indexVar, ';break}',
           '++', indexVar, ';',
           '}while(true)',

--- a/src/main/readers/until.ts
+++ b/src/main/readers/until.ts
@@ -4,7 +4,7 @@ import {CharCodeRange, CharCodeRangeReader, createCharPredicateCode} from './cha
 import {never} from './never';
 import {none} from './none';
 import {Reader, ReaderCodegen} from './reader-types';
-import {createCodeBindings, createReaderCallCode, NO_MATCH} from './reader-utils';
+import {createCodeBindings, createReaderCallCode} from './reader-utils';
 import {CaseSensitiveTextReader} from './text';
 
 export interface UntilOptions {
@@ -58,7 +58,7 @@ export class UntilCharCodeRangeReader implements ReaderCodegen {
     const charCodeVar = createVar();
 
     return createCodeBindings([
-      resultVar, '=' + NO_MATCH + ';',
+      resultVar, '=-1;',
 
       'var ',
       inputLengthVar, '=', inputVar, '.length,',
@@ -89,7 +89,7 @@ export class UntilCaseSensitiveTextReader implements ReaderCodegen {
     return createCodeBindings(
         [
           'var ', indexVar, '=', inputVar, '.indexOf(', strVar, ',', offsetVar, ');',
-          resultVar, '=', indexVar, this.inclusive ? ['===-1?' + NO_MATCH + ':', indexVar, '+', str.length] : '', ';',
+          resultVar, '=', indexVar, this.inclusive ? ['===-1?-1:', indexVar, '+', str.length] : '', ';',
         ],
         [[strVar, str]],
     );
@@ -109,7 +109,7 @@ export class UntilReader<Context> implements ReaderCodegen {
 
     return createCodeBindings(
         [
-          resultVar, '=' + NO_MATCH + ';',
+          resultVar, '=-1;',
 
           'var ',
           indexVar, '=', offsetVar, ',',

--- a/src/main/rules/compileRuleIterator.ts
+++ b/src/main/rules/compileRuleIterator.ts
@@ -115,14 +115,14 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
     'while(', nextOffsetVar, '<', chunkLengthVar, '){',
 
     // Apply rules from the current stage
-    branchesByStageIndex.length ? [
+    branchesByStageIndex.length === 0 ? createRuleIteratorBranchesCode(branches, nextOffsetVar, false) : [
       'switch(', stageIndexVar, '){',
       branchesByStageIndex.map((branches, stageIndex) => [
         'case ', stageIndex, ':', createRuleIteratorBranchesCode(branches, nextOffsetVar, true),
         'break;'
       ]),
       '}',
-    ] : createRuleIteratorBranchesCode(branches, nextOffsetVar, false),
+    ],
 
     'break}',
 
@@ -134,7 +134,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
     '}',
 
     // Update stage only if stages are enabled
-    branchesByStageIndex.length ? [stateVar, '.stage=', stagesVar, '[', stageIndexVar, '];'] : '',
+    branchesByStageIndex.length === 0 ? '' : [stateVar, '.stage=', stagesVar, '[', stageIndexVar, '];'],
     stateVar, '.offset=', nextOffsetVar, ';',
   ];
 

--- a/src/main/rules/compileRuleIterator.ts
+++ b/src/main/rules/compileRuleIterator.ts
@@ -25,7 +25,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
   const chunkVar = createVar();
   const offsetVar = createVar();
 
-  const prevRuleIndexVar = createVar();
+  const prevRuleIdVar = createVar();
   const prevRuleTypeVar = createVar();
   const nextOffsetVar = createVar();
   const chunkLengthVar = createVar();
@@ -78,16 +78,16 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
       code.push([
 
         // Emit confirmed token
-        'if(', prevRuleIndexVar, '!==-1){',
+        'if(', prevRuleIdVar, '!==-1){',
         handlerVar, '(', prevRuleTypeVar, ',', chunkVar, ',', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
-        prevRuleIndexVar, '=-1}',
+        prevRuleIdVar, '=-1}',
 
         // If stagesEnabled then stageIndex is never -1 so no out-of-bounds check is required
         stagesEnabled ? [stateVar, '.stage=', stagesIndexed ? [stagesVar, '[', stageVar, ']'] : stageVar, ';'] : '',
         stateVar, '.offset=', offsetVar, '=', nextOffsetVar, ';',
 
         rule.silent ? '' : [
-          prevRuleIndexVar, '=', branch.ruleIndex, ';',
+          prevRuleIdVar, '=', branch.ruleId, ';',
           prevRuleTypeVar, '=', ruleTypeVar, ';',
         ],
 
@@ -112,7 +112,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
     chunkVar, '=', stateVar, '.chunk,',
     offsetVar, '=', stateVar, '.offset,',
 
-    prevRuleIndexVar, '=-1,',
+    prevRuleIdVar, '=-1,',
     prevRuleTypeVar, ',',
     nextOffsetVar, '=', offsetVar, ',',
     chunkLengthVar, '=', chunkVar, '.length;',
@@ -137,7 +137,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
     'if(', streamingVar, ')return;',
 
     // Emit last unconfirmed token
-    'if(', prevRuleIndexVar, '!==-1){',
+    'if(', prevRuleIdVar, '!==-1){',
     handlerVar, '(', prevRuleTypeVar, ',', chunkVar, ',', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
     '}',
 

--- a/src/main/rules/compileRuleIterator.ts
+++ b/src/main/rules/compileRuleIterator.ts
@@ -23,9 +23,6 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
   const chunkVar = createVar();
   const offsetVar = createVar();
 
-  const tokenCallbackVar = createVar();
-  const unrecognizedTokenCallbackVar = createVar();
-
   const prevRuleIndexVar = createVar();
   const prevRuleTypeVar = createVar();
   const nextOffsetVar = createVar();
@@ -77,7 +74,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
 
         // Emit confirmed token
         'if(', prevRuleIndexVar, '!==-1){',
-        tokenCallbackVar, '(', prevRuleTypeVar, ',', chunkVar, ',', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
+        handlerVar, '(', prevRuleTypeVar, ',', chunkVar, ',', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
         prevRuleIndexVar, '=-1}',
 
         // If stagesEnabled === true then stageIndex !== -1
@@ -109,8 +106,6 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
     stageIndexVar, '=', stagesVar, '.indexOf(', stateVar, '.stage),',
     chunkVar, '=', stateVar, '.chunk,',
     offsetVar, '=', stateVar, '.offset,',
-    tokenCallbackVar, '=', handlerVar, '.token,',
-    unrecognizedTokenCallbackVar, '=', handlerVar, '.unrecognizedToken,',
 
     prevRuleIndexVar, '=-1,',
     prevRuleTypeVar, ',',
@@ -135,17 +130,12 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
 
     // Emit trailing unconfirmed token
     'if(', prevRuleIndexVar, '!==-1){',
-    tokenCallbackVar, '(', prevRuleTypeVar, ',', chunkVar, ',', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
+    handlerVar, '(', prevRuleTypeVar, ',', chunkVar, ',', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
     '}',
 
     // Update stage only if stages are enabled
     branchesByStageIndex.length ? [stateVar, '.stage=', stagesVar, '[', stageIndexVar, '];'] : '',
     stateVar, '.offset=', nextOffsetVar, ';',
-
-    // Trigger unrecognized token
-    nextOffsetVar, '!==', chunkLengthVar,
-    '&&', unrecognizedTokenCallbackVar,
-    '&&', unrecognizedTokenCallbackVar, '(', chunkVar, ',', nextOffsetVar, ',', contextVar, ',', stateVar, ');',
   ];
 
   return compileFunction<RuleIterator<Type, Stage, Context>>([stateVar, handlerVar, contextVar, streamingVar], code, bindings);

--- a/src/main/rules/compileRuleIterator.ts
+++ b/src/main/rules/compileRuleIterator.ts
@@ -1,5 +1,6 @@
-import {Binding, Code, compileFunction, createVar, Var} from 'codedegen';
+import {Binding, Code, compileFunction, Var} from 'codedegen';
 import {createReaderCallCode, seq} from '../readers';
+import {createVar} from '../utils';
 import {RuleBranch, RuleTree} from './createRuleTree';
 import {TokenHandler, TokenizerState} from './rule-types';
 

--- a/src/main/rules/compileRuleIterator.ts
+++ b/src/main/rules/compileRuleIterator.ts
@@ -25,7 +25,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
   const chunkVar = createVar();
   const offsetVar = createVar();
 
-  const prevRuleIdVar = createVar();
+  const prevRulePendingVar = createVar();
   const prevRuleTypeVar = createVar();
   const nextOffsetVar = createVar();
   const chunkLengthVar = createVar();
@@ -80,16 +80,16 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
       code.push([
 
         // Emit confirmed token
-        'if(', prevRuleIdVar, '!==-1){',
+        'if(', prevRulePendingVar, '){',
         handlerVar, '(', prevRuleTypeVar, ',', chunkVar, ',', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
-        prevRuleIdVar, '=-1}',
+        prevRulePendingVar, '=false}',
 
         // If stagesEnabled then stageIndex is never -1 so no out-of-bounds check is required
         stagesEnabled ? [stateVar, '.stage=', stagesInlined ? stageVar : [stagesVar, '[', stageVar, ']'], ';'] : '',
         stateVar, '.offset=', offsetVar, '=', nextOffsetVar, ';',
 
         rule.silent ? '' : [
-          prevRuleIdVar, '=', branch.ruleId, ';',
+          prevRulePendingVar, '=true;',
           prevRuleTypeVar, '=', typeInlined ? JSON.stringify(type) : typeVar, ';',
         ],
 
@@ -114,7 +114,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
     chunkVar, '=', stateVar, '.chunk,',
     offsetVar, '=', stateVar, '.offset,',
 
-    prevRuleIdVar, '=-1,',
+    prevRulePendingVar, '=false,',
     prevRuleTypeVar, ',',
     nextOffsetVar, '=', offsetVar, ',',
     chunkLengthVar, '=', chunkVar, '.length;',
@@ -139,7 +139,7 @@ export function compileRuleIterator<Type, Stage, Context>(tree: RuleTree<Type, S
     'if(', streamingVar, ')return;',
 
     // Emit last unconfirmed token
-    'if(', prevRuleIdVar, '!==-1){',
+    'if(', prevRulePendingVar, '){',
     handlerVar, '(', prevRuleTypeVar, ',', chunkVar, ',', offsetVar, ',', nextOffsetVar, '-', offsetVar, ',', contextVar, ',', stateVar, ');',
     '}',
 

--- a/src/main/rules/createRuleTree.ts
+++ b/src/main/rules/createRuleTree.ts
@@ -38,9 +38,9 @@ export interface RuleBranch<Type, Stage, Context> {
   rule?: Rule<Type, Stage, Context>;
 
   /**
-   * The rule index, can be used as a rule UID.
+   * The rule ID that is unique in scope of the tree.
    */
-  ruleIndex?: number;
+  ruleId?: number;
 }
 
 /**
@@ -70,21 +70,21 @@ export function createRuleTree<Type, Stage, Context>(rules: Rule<Type, Stage, Co
   for (const rule of rules) {
 
     // Ensure the ID is unique and rule always has the same ID
-    const ruleIndex = rules.indexOf(rule);
+    const ruleId = rules.indexOf(rule);
 
     // Append the rule to branches
     if (rule.on) {
       for (const stage of rule.on) {
-        appendRule(branchesOnStage[stages.indexOf(stage)], rule, ruleIndex);
+        appendRule(branchesOnStage[stages.indexOf(stage)], rule, ruleId);
       }
       continue;
     }
 
     // Rule has no stages defined, so it is applied on every stage
     for (const stagePlan of branchesOnStage) {
-      appendRule(stagePlan, rule, ruleIndex);
+      appendRule(stagePlan, rule, ruleId);
     }
-    appendRule(branches, rule, ruleIndex);
+    appendRule(branches, rule, ruleId);
   }
 
   return {
@@ -99,18 +99,18 @@ export function createRuleTree<Type, Stage, Context>(rules: Rule<Type, Stage, Co
  *
  * @param branches The mutable list of branches to which the rule must be appended.
  * @param rule The rule to append.
- * @param ruleIndex The rule UID.
+ * @param ruleId The rule UID.
  * @returns The updated list of branches.
  */
-export function appendRule<Type, Stage, Context>(branches: RuleBranch<Type, Stage, Context>[], rule: Rule<Type, Stage, Context>, ruleIndex: number): RuleBranch<Type, Stage, Context>[] {
+export function appendRule<Type, Stage, Context>(branches: RuleBranch<Type, Stage, Context>[], rule: Rule<Type, Stage, Context>, ruleId: number): RuleBranch<Type, Stage, Context>[] {
   const {reader} = rule;
 
-  distributeRule(branches, reader instanceof SeqReader ? reader.readers : [reader], rule, ruleIndex);
+  distributeRule(branches, reader instanceof SeqReader ? reader.readers : [reader], rule, ruleId);
 
   return branches;
 }
 
-function distributeRule<Type, Stage, Context>(branches: RuleBranch<Type, Stage, Context>[], readers: Reader<Context>[], rule: Rule<Type, Stage, Context>, ruleIndex: number): void {
+function distributeRule<Type, Stage, Context>(branches: RuleBranch<Type, Stage, Context>[], readers: Reader<Context>[], rule: Rule<Type, Stage, Context>, ruleId: number): void {
 
   const readersLength = readers.length;
 
@@ -143,12 +143,12 @@ function distributeRule<Type, Stage, Context>(branches: RuleBranch<Type, Stage, 
       if (j === readersLength) {
         // Terminates the branch
         branch.rule = rule;
-        branch.ruleIndex = ruleIndex;
+        branch.ruleId = ruleId;
         return;
       }
 
       // Distribute remaining readers
-      distributeRule(branch.children!, readers.slice(j), rule, ruleIndex);
+      distributeRule(branch.children!, readers.slice(j), rule, ruleId);
       return;
     }
 
@@ -159,21 +159,21 @@ function distributeRule<Type, Stage, Context>(branches: RuleBranch<Type, Stage, 
           readers: branchReaders.slice(j),
           children: branch.children,
           rule: branch.rule,
-          ruleIndex: branch.ruleIndex,
+          ruleId: branch.ruleId,
         }
       ],
     };
 
     if (j === readersLength) {
       branch.rule = rule;
-      branch.ruleIndex = ruleIndex;
+      branch.ruleId = ruleId;
       return;
     }
 
     branch.children!.push({
       readers: readers.slice(j),
       rule,
-      ruleIndex,
+      ruleId,
     });
     return;
   }
@@ -181,6 +181,6 @@ function distributeRule<Type, Stage, Context>(branches: RuleBranch<Type, Stage, 
   branches.push({
     readers,
     rule,
-    ruleIndex,
+    ruleId,
   });
 }

--- a/src/main/rules/createRuleTree.ts
+++ b/src/main/rules/createRuleTree.ts
@@ -11,10 +11,10 @@ export interface RuleTree<Type, Stage, Context> {
   /**
    * The list of branches parallel to {@link stages}. May be empty if rules didn't define any stages.
    */
-  branchesByStageIndex: RuleBranch<Type, Stage, Context>[][];
+  branchesOnStage: RuleBranch<Type, Stage, Context>[][];
 
   /**
-   * The list of branches that are used if there are no stages and {@link branchesByStageIndex} is empty.
+   * The list of branches that are used if there are no stages and {@link branchesOnStage} is empty.
    */
   branches: RuleBranch<Type, Stage, Context>[];
 }
@@ -60,11 +60,11 @@ export function createRuleTree<Type, Stage, Context>(rules: Rule<Type, Stage, Co
     }
   }
 
-  const branchesByStageIndex: RuleBranch<Type, Stage, Context>[][] = [];
+  const branchesOnStage: RuleBranch<Type, Stage, Context>[][] = [];
   const branches: RuleBranch<Type, Stage, Context>[] = [];
 
   for (let i = 0; i < stages.length; ++i) {
-    branchesByStageIndex.push([]);
+    branchesOnStage.push([]);
   }
 
   for (const rule of rules) {
@@ -75,13 +75,13 @@ export function createRuleTree<Type, Stage, Context>(rules: Rule<Type, Stage, Co
     // Append the rule to branches
     if (rule.on) {
       for (const stage of rule.on) {
-        appendRule(branchesByStageIndex[stages.indexOf(stage)], rule, ruleIndex);
+        appendRule(branchesOnStage[stages.indexOf(stage)], rule, ruleIndex);
       }
       continue;
     }
 
     // Rule has no stages defined, so it is applied on every stage
-    for (const stagePlan of branchesByStageIndex) {
+    for (const stagePlan of branchesOnStage) {
       appendRule(stagePlan, rule, ruleIndex);
     }
     appendRule(branches, rule, ruleIndex);
@@ -89,7 +89,7 @@ export function createRuleTree<Type, Stage, Context>(rules: Rule<Type, Stage, Co
 
   return {
     stages,
-    branchesByStageIndex,
+    branchesOnStage,
     branches,
   };
 }

--- a/src/main/rules/createRuleTree.ts
+++ b/src/main/rules/createRuleTree.ts
@@ -1,7 +1,7 @@
 import {Reader, SeqReader} from '../readers';
 import {Rule} from './rule-types';
 
-export interface RuleTree<Type, Stage, Context, Error> {
+export interface RuleTree<Type, Stage, Context> {
 
   /**
    * The set of the unique stages at which rules are applied. May be empty if rules didn't define any stages.
@@ -11,31 +11,31 @@ export interface RuleTree<Type, Stage, Context, Error> {
   /**
    * The list of branches parallel to {@link stages}. May be empty if rules didn't define any stages.
    */
-  branchesByStageIndex: RuleBranch<Type, Stage, Context, Error>[][];
+  branchesByStageIndex: RuleBranch<Type, Stage, Context>[][];
 
   /**
    * The list of branches that are used if there are no stages and {@link branchesByStageIndex} is empty.
    */
-  branches: RuleBranch<Type, Stage, Context, Error>[];
+  branches: RuleBranch<Type, Stage, Context>[];
 }
 
-export interface RuleBranch<Type, Stage, Context, Error> {
+export interface RuleBranch<Type, Stage, Context> {
 
   /**
    * The non-empty list of readers that should sequentially read chars from the input to proceed to {@link children}
    * and/or {@link rule}.
    */
-  readers: Reader<Context, Error>[];
+  readers: Reader<Context>[];
 
   /**
    * The optional list of branches that must be tried before the rule is applied.
    */
-  children?: RuleBranch<Type, Stage, Context, Error>[];
+  children?: RuleBranch<Type, Stage, Context>[];
 
   /**
    * The optional rule that must be applied if none of the children matched.
    */
-  rule?: Rule<Type, Stage, Context, Error>;
+  rule?: Rule<Type, Stage, Context>;
 
   /**
    * The rule index, can be used as a rule UID.
@@ -46,7 +46,7 @@ export interface RuleBranch<Type, Stage, Context, Error> {
 /**
  * Creates a tree that describes the most efficient way to apply tokenization rules.
  */
-export function createRuleTree<Type, Stage, Context, Error>(rules: Rule<Type, Stage, Context, Error>[]): RuleTree<Type, Stage, Context, Error> {
+export function createRuleTree<Type, Stage, Context>(rules: Rule<Type, Stage, Context>[]): RuleTree<Type, Stage, Context> {
   const stages: Stage[] = [];
 
   // Collect unique stages
@@ -60,8 +60,8 @@ export function createRuleTree<Type, Stage, Context, Error>(rules: Rule<Type, St
     }
   }
 
-  const branchesByStageIndex: RuleBranch<Type, Stage, Context, Error>[][] = [];
-  const branches: RuleBranch<Type, Stage, Context, Error>[] = [];
+  const branchesByStageIndex: RuleBranch<Type, Stage, Context>[][] = [];
+  const branches: RuleBranch<Type, Stage, Context>[] = [];
 
   for (let i = 0; i < stages.length; ++i) {
     branchesByStageIndex.push([]);
@@ -102,7 +102,7 @@ export function createRuleTree<Type, Stage, Context, Error>(rules: Rule<Type, St
  * @param ruleIndex The rule UID.
  * @returns The updated list of branches.
  */
-export function appendRule<Type, Stage, Context, Error>(branches: RuleBranch<Type, Stage, Context, Error>[], rule: Rule<Type, Stage, Context, Error>, ruleIndex: number): RuleBranch<Type, Stage, Context, Error>[] {
+export function appendRule<Type, Stage, Context>(branches: RuleBranch<Type, Stage, Context>[], rule: Rule<Type, Stage, Context>, ruleIndex: number): RuleBranch<Type, Stage, Context>[] {
   const {reader} = rule;
 
   distributeRule(branches, reader instanceof SeqReader ? reader.readers : [reader], rule, ruleIndex);
@@ -110,7 +110,7 @@ export function appendRule<Type, Stage, Context, Error>(branches: RuleBranch<Typ
   return branches;
 }
 
-function distributeRule<Type, Stage, Context, Error>(branches: RuleBranch<Type, Stage, Context, Error>[], readers: Reader<Context, Error>[], rule: Rule<Type, Stage, Context, Error>, ruleIndex: number): void {
+function distributeRule<Type, Stage, Context>(branches: RuleBranch<Type, Stage, Context>[], readers: Reader<Context>[], rule: Rule<Type, Stage, Context>, ruleIndex: number): void {
 
   const readersLength = readers.length;
 

--- a/src/main/rules/rule-types.ts
+++ b/src/main/rules/rule-types.ts
@@ -21,14 +21,13 @@ export type StageProvider<Stage, Context> = (chunk: string, offset: number, leng
  * @template Type The type of the token emitted by this rule.
  * @template Stage The tokenizer stage type.
  * @template Context The context passed by tokenizer.
- * @template Error The error that the reader may return.
  */
-export interface Rule<Type = unknown, Stage = void, Context = void, Error = never> {
+export interface Rule<Type = unknown, Stage = void, Context = void> {
 
   /**
    * The reader that reads chars from the string.
    */
-  reader: Reader<Context, Error | number>;
+  reader: Reader<Context>;
 
   /**
    * The type of the token that is passed to {@link TokenHandler.token} when the rule successfully reads chars from the
@@ -73,22 +72,22 @@ export interface TokenizerState<Stage = void> {
   /**
    * The current tokenizer stage.
    */
-  readonly stage: Stage;
+  stage: Stage;
 
   /**
    * The chunk that is being processed.
    */
-  readonly chunk: string;
-
-  /**
-   * The offset in the {@link chunk} from which the tokenization should proceed.
-   */
-  readonly offset: number;
+  chunk: string;
 
   /**
    * The offset of the {@link chunk} in the input stream.
    */
-  readonly chunkOffset: number;
+  chunkOffset: number;
+
+  /**
+   * The offset in the {@link chunk} from which the tokenization should proceed.
+   */
+  offset: number;
 }
 
 /**
@@ -96,9 +95,8 @@ export interface TokenizerState<Stage = void> {
  *
  * @template Type The type of tokens emitted by rules.
  * @template Context The context passed by tokenizer.
- * @template Error The error that the reader may return.
  */
-export interface TokenHandler<Type = unknown, Context = void, Error = never> {
+export interface TokenHandler<Type = unknown, Context = void> {
 
   /**
    * Triggered when a token was read from the input stream.
@@ -123,18 +121,6 @@ export interface TokenHandler<Type = unknown, Context = void, Error = never> {
    * @param state The current state of the tokenizer.
    */
   token(type: Type, chunk: string, offset: number, length: number, context: Context, state: TokenizerState): void;
-
-  /**
-   * Triggered when the rule returned an error code.
-   *
-   * @param type The type of the token that caused an error while reading.
-   * @param chunk The input chunk from which the token was read.
-   * @param offset The chunk-relative offset where the token starts.
-   * @param error The error returned by the reader.
-   * @param context The context passed by the tokenizer.
-   * @param state The current state of the tokenizer.
-   */
-  error?(type: Type, chunk: string, offset: number, error: Error, context: Context, state: TokenizerState): void;
 
   /**
    * Triggered if there was no rule that could successfully read a token at the offset.

--- a/src/main/rules/rule-types.ts
+++ b/src/main/rules/rule-types.ts
@@ -30,8 +30,8 @@ export interface Rule<Type = unknown, Stage = void, Context = void> {
   reader: Reader<Context>;
 
   /**
-   * The type of the token that is passed to {@link TokenHandler.token} when the rule successfully reads chars from the
-   * input string. Type isn't required to be unique, so multiple rules may share the same type if needed.
+   * The type of the token that is passed to {@link TokenHandler} when the rule successfully reads chars from the input
+   * string. Type isn't required to be unique, so multiple rules may share the same type if needed.
    *
    * @default undefined
    */
@@ -91,44 +91,28 @@ export interface TokenizerState<Stage = void> {
 }
 
 /**
- * Handles tokens read from the input string.
+ * Triggered when a token was read from the input stream.
+ *
+ * The substring of the current token:
+ *
+ * ```ts
+ * const tokenValue = chunk.substr(offset, length);
+ * ```
+ *
+ * The offset of this token from the start of the input stream (useful if you're using {@link Tokenizer.write}):
+ *
+ * ```ts
+ * const absoluteOffset = state.chunkOffset + offset;
+ * ```
+ *
+ * @param type The type of the token that was read.
+ * @param chunk The input chunk from which the token was read.
+ * @param offset The chunk-relative offset from the start of the input stream where the token starts.
+ * @param length The number of chars read by the rule.
+ * @param context The context passed by the tokenizer.
+ * @param state The current state of the tokenizer.
  *
  * @template Type The type of tokens emitted by rules.
  * @template Context The context passed by tokenizer.
  */
-export interface TokenHandler<Type = unknown, Context = void> {
-
-  /**
-   * Triggered when a token was read from the input stream.
-   *
-   * The substring of the current token:
-   *
-   * ```ts
-   * const tokenValue = chunk.substr(offset, length);
-   * ```
-   *
-   * The offset of this token from the start of the input stream (useful if you're using {@link Tokenizer.write}):
-   *
-   * ```ts
-   * const absoluteOffset = state.chunkOffset + offset;
-   * ```
-   *
-   * @param type The type of the token that was read.
-   * @param chunk The input chunk from which the token was read.
-   * @param offset The chunk-relative offset from the start of the input stream where the token starts.
-   * @param length The number of chars read by the rule.
-   * @param context The context passed by the tokenizer.
-   * @param state The current state of the tokenizer.
-   */
-  token(type: Type, chunk: string, offset: number, length: number, context: Context, state: TokenizerState): void;
-
-  /**
-   * Triggered if there was no rule that could successfully read a token at the offset.
-   *
-   * @param chunk The input chunk from which tokens are read.
-   * @param offset The chunk-relative offset where the unrecognized token starts.
-   * @param context The context passed by the tokenizer.
-   * @param state The current state of the tokenizer.
-   */
-  unrecognizedToken?(chunk: string, offset: number, context: Context, state: TokenizerState): void;
-}
+export type TokenHandler<Type = unknown, Context = void> = (type: Type, chunk: string, offset: number, length: number, context: Context, state: TokenizerState) => void;

--- a/src/main/rules/rule-types.ts
+++ b/src/main/rules/rule-types.ts
@@ -67,7 +67,7 @@ export interface Rule<Type = unknown, Stage = void, Context = void> {
  *
  * @template Stage The tokenizer stage type.
  */
-export interface TokenizerState<Stage = void> {
+export interface TokenizerState<Stage = any> {
 
   /**
    * The current tokenizer stage.

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,7 +1,13 @@
+import {Var} from 'codedegen';
+
 export function die(message?: string): never {
   throw new Error(message);
 }
 
 export function toInteger(value: number | undefined, defaultValue?: number, minimumValue?: number): number {
   return Math.max((value || defaultValue || 0) | 0, minimumValue || 0);
+}
+
+export function createVar(): Var {
+  return Symbol();
 }

--- a/src/test/createTokenizer.test.ts
+++ b/src/test/createTokenizer.test.ts
@@ -2,23 +2,14 @@ import {all, char, createTokenizer, Reader, Rule, text, TokenHandler} from '../m
 
 describe('createTokenizer', () => {
 
-  const tokenCallbackMock = jest.fn();
-  const errorCallbackMock = jest.fn();
-  const unrecognizedTokenCallbackMock = jest.fn();
+  const handlerMock = jest.fn();
 
-  const handler: TokenHandler = {
-    token(type, chunk, offset, length, context, state) {
-      tokenCallbackMock(type, state.chunkOffset + offset, length, context);
-    },
-    unrecognizedToken(chunk, offset, context, state) {
-      unrecognizedTokenCallbackMock(state.chunkOffset + offset, context);
-    }
+  const handler: TokenHandler = (type, chunk, offset, length, context, state) => {
+    handlerMock(type, state.chunkOffset + offset, length, context);
   };
 
   beforeEach(() => {
-    tokenCallbackMock.mockRestore();
-    errorCallbackMock.mockRestore();
-    unrecognizedTokenCallbackMock.mockRestore();
+    handlerMock.mockRestore();
   });
 
   test('reads tokens in non-streaming mode', () => {
@@ -39,10 +30,10 @@ describe('createTokenizer', () => {
       offset: 5
     });
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(3);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(1, 'TypeA', 0, 1, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(2, 'TypeA', 1, 1, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(3, 'TypeB', 2, 3, undefined);
+    expect(handlerMock).toHaveBeenCalledTimes(3);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TypeA', 0, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TypeA', 1, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TypeB', 2, 3, undefined);
   });
 
   test('reads tokens in streaming mode', () => {
@@ -56,26 +47,23 @@ describe('createTokenizer', () => {
 
     const state = tokenizer.write('aabbb', handler);
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(2);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(1, 'TypeA', 0, 1, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(2, 'TypeA', 1, 1, undefined);
+    expect(handlerMock).toHaveBeenCalledTimes(2);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TypeA', 0, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TypeA', 1, 1, undefined);
 
     tokenizer.write('BBB', handler, state);
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(2);
+    expect(handlerMock).toHaveBeenCalledTimes(2);
 
     tokenizer.write('a', handler, state);
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(3);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(3, 'TypeB', 2, 6, undefined);
+    expect(handlerMock).toHaveBeenCalledTimes(3);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TypeB', 2, 6, undefined);
 
     tokenizer.end(handler, state);
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(4);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(4, 'TypeA', 8, 1, undefined);
-
-    expect(errorCallbackMock).not.toHaveBeenCalled();
-    expect(unrecognizedTokenCallbackMock).not.toHaveBeenCalled();
+    expect(handlerMock).toHaveBeenCalledTimes(4);
+    expect(handlerMock).toHaveBeenNthCalledWith(4, 'TypeA', 8, 1, undefined);
   });
 
   test('reads tokens with reader function', () => {
@@ -89,7 +77,7 @@ describe('createTokenizer', () => {
 
     tokenizer('abc', handler);
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(3);
+    expect(handlerMock).toHaveBeenCalledTimes(3);
     expect(readerMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/test/perf.js
+++ b/src/test/perf.js
@@ -20,10 +20,7 @@ describe('Tokenizer', () => {
 
       const reWhitespace = /[ \t\r\n]+/y;
 
-      const handler = {
-        token(chunk, offset, length) {
-        },
-      };
+      const handler = () => undefined;
 
       const tokenizer = (input, stage, offset, handler) => {
         let lastIndex;
@@ -36,7 +33,7 @@ describe('Tokenizer', () => {
 
               reNumber.lastIndex = offset;
               if (reNumber.test(input) && offset < (lastIndex = reNumber.lastIndex)) {
-                handler.token(input, offset, lastIndex - offset);
+                handler(input, offset, lastIndex - offset);
                 offset = lastIndex;
                 stage = 1;
                 continue;
@@ -44,7 +41,7 @@ describe('Tokenizer', () => {
 
               reAlpha.lastIndex = offset;
               if (reAlpha.test(input) && offset < (lastIndex = reAlpha.lastIndex)) {
-                handler.token(input, offset, lastIndex - offset);
+                handler(input, offset, lastIndex - offset);
                 offset = lastIndex;
                 stage = 1;
                 continue;
@@ -119,13 +116,13 @@ describe('Tokenizer', () => {
       const tokenizer = next.createTokenizer([
         {
           on: [0],
-          type: 'ALPHA',
+          type: 111,
           reader: alphaReader,
           to: 1,
         },
         {
           on: [0],
-          type: 'NUMBER',
+          type: 222,
           reader: numberReader,
           to: 1,
         },
@@ -141,10 +138,7 @@ describe('Tokenizer', () => {
         },
       ], 0);
 
-      const handler = {
-        token(chunk, type, offset, length, context, state) {
-        },
-      };
+      const handler = () => undefined;
 
       measure(() => tokenizer(input, handler));
 
@@ -167,10 +161,7 @@ describe('Tokenizer', () => {
 
       const reWhitespace = /[ \t\r\n]+/y;
 
-      const handler = {
-        token(chunk, offset, length) {
-        },
-      };
+      const handler = () => undefined;
 
       const tokenizer = (input, offset, handler) => {
         let lastIndex;
@@ -179,14 +170,14 @@ describe('Tokenizer', () => {
 
           reNumber.lastIndex = offset;
           if (reNumber.test(input) && offset < (lastIndex = reNumber.lastIndex)) {
-            handler.token(input, offset, lastIndex - offset);
+            handler(input, offset, lastIndex - offset);
             offset = lastIndex;
             continue;
           }
 
           reAlpha.lastIndex = offset;
           if (reAlpha.test(input) && offset < (lastIndex = reAlpha.lastIndex)) {
-            handler.token(input, offset, lastIndex - offset);
+            handler(input, offset, lastIndex - offset);
             offset = lastIndex;
             continue;
           }
@@ -253,11 +244,11 @@ describe('Tokenizer', () => {
 
       const tokenizer = next.createTokenizer([
         {
-          type: 'ALPHA',
+          type: 111,
           reader: alphaReader,
         },
         {
-          type: 'NUMBER',
+          type: 222,
           reader: numberReader,
         },
         {
@@ -270,10 +261,7 @@ describe('Tokenizer', () => {
         },
       ]);
 
-      const handler = {
-        token(chunk, type, offset, length, context, state) {
-        },
-      };
+      const handler = () => undefined;
 
       measure(() => tokenizer(input, handler));
 

--- a/src/test/readers/all.test.ts
+++ b/src/test/readers/all.test.ts
@@ -1,4 +1,4 @@
-import {all, AllReader, never, NO_MATCH, none, text, toReaderFunction} from '../../main/readers';
+import {all, AllReader, never, none, text, toReaderFunction} from '../../main/readers';
 
 describe('all', () => {
 
@@ -32,11 +32,11 @@ describe('all', () => {
 
 describe('AllReader', () => {
 
-  test('reads until reader returns NO_MATCH', () => {
+  test('reads until reader returns -1', () => {
     const readerMock = jest.fn();
     readerMock.mockReturnValueOnce(3);
     readerMock.mockReturnValueOnce(4);
-    readerMock.mockReturnValueOnce(NO_MATCH);
+    readerMock.mockReturnValueOnce(-1);
 
     expect(toReaderFunction(new AllReader(readerMock, 0, 0))('aabbcc', 2)).toBe(4);
     expect(readerMock).toHaveBeenCalledTimes(3);
@@ -51,12 +51,12 @@ describe('AllReader', () => {
     expect(readerMock).toHaveBeenCalledTimes(2);
   });
 
-  test('returns NO_MATCH if minimum matches was not reached', () => {
+  test('returns -1 if minimum matches was not reached', () => {
     const readerMock = jest.fn();
     readerMock.mockReturnValueOnce(1);
-    readerMock.mockReturnValueOnce(NO_MATCH);
+    readerMock.mockReturnValueOnce(-1);
 
-    expect(toReaderFunction(new AllReader(readerMock, 2, 0))('a', 0)).toBe(NO_MATCH);
+    expect(toReaderFunction(new AllReader(readerMock, 2, 0))('a', 0)).toBe(-1);
     expect(readerMock).toHaveBeenCalledTimes(2);
   });
 
@@ -65,7 +65,7 @@ describe('AllReader', () => {
     readerMock.mockReturnValueOnce(1);
     readerMock.mockReturnValueOnce(2);
     readerMock.mockReturnValueOnce(3);
-    readerMock.mockReturnValueOnce(NO_MATCH);
+    readerMock.mockReturnValueOnce(-1);
 
     expect(toReaderFunction(new AllReader(readerMock, 2, 0))('aaa', 0)).toBe(3);
     expect(readerMock).toHaveBeenCalledTimes(4);
@@ -84,7 +84,7 @@ describe('AllReader', () => {
   test('maximum does not affect the minimum', () => {
     const readerMock = jest.fn();
     readerMock.mockReturnValueOnce(1);
-    readerMock.mockReturnValueOnce(NO_MATCH);
+    readerMock.mockReturnValueOnce(-1);
 
     expect(toReaderFunction(new AllReader(readerMock, 0, 2))('a', 0)).toBe(1);
     expect(readerMock).toHaveBeenCalledTimes(2);

--- a/src/test/readers/all.test.ts
+++ b/src/test/readers/all.test.ts
@@ -51,16 +51,6 @@ describe('AllReader', () => {
     expect(readerMock).toHaveBeenCalledTimes(2);
   });
 
-  test('returns error result from underlying reader', () => {
-    const readerMock = jest.fn();
-    readerMock.mockReturnValueOnce(3);
-    readerMock.mockReturnValueOnce('Error');
-    readerMock.mockReturnValueOnce(3);
-
-    expect(toReaderFunction(new AllReader(readerMock, 0, 0))('aabbcc', 2)).toBe('Error');
-    expect(readerMock).toHaveBeenCalledTimes(2);
-  });
-
   test('returns NO_MATCH if minimum matches was not reached', () => {
     const readerMock = jest.fn();
     readerMock.mockReturnValueOnce(1);

--- a/src/test/readers/char.test.ts
+++ b/src/test/readers/char.test.ts
@@ -1,4 +1,4 @@
-import {char, CharCodeRangeReader, NO_MATCH, none, toReaderFunction} from '../../main/readers';
+import {char, CharCodeRangeReader, none, toReaderFunction} from '../../main/readers';
 
 const A = 'a'.charCodeAt(0);
 
@@ -26,6 +26,6 @@ describe('CharCodeRangeReader', () => {
   });
 
   test('does not read unmatched char', () => {
-    expect(toReaderFunction(new CharCodeRangeReader([A]))('aaabbb', 4)).toBe(NO_MATCH);
+    expect(toReaderFunction(new CharCodeRangeReader([A]))('aaabbb', 4)).toBe(-1);
   });
 });

--- a/src/test/readers/lookahead.test.ts
+++ b/src/test/readers/lookahead.test.ts
@@ -1,4 +1,4 @@
-import {lookahead, LookaheadReader, never, NO_MATCH, none, text, toReaderFunction} from '../../main/readers';
+import {lookahead, LookaheadReader, never, none, text, toReaderFunction} from '../../main/readers';
 
 describe('lookahead', () => {
 
@@ -27,7 +27,7 @@ describe('LookaheadReader', () => {
 
   test('can use inline readers', () => {
     expect(toReaderFunction(new LookaheadReader(text('aa')))('aabbcc', 0)).toBe(0);
-    expect(toReaderFunction(new LookaheadReader(text('bb')))('aabbcc', 0)).toBe(NO_MATCH);
+    expect(toReaderFunction(new LookaheadReader(text('bb')))('aabbcc', 0)).toBe(-1);
   });
 
   test('propagates context', () => {

--- a/src/test/readers/maybe.test.ts
+++ b/src/test/readers/maybe.test.ts
@@ -1,4 +1,4 @@
-import {maybe, MaybeReader, never, NO_MATCH, none, text, toReaderFunction} from '../../main/readers';
+import {maybe, MaybeReader, never, none, text, toReaderFunction} from '../../main/readers';
 
 describe('maybe', () => {
 
@@ -24,7 +24,7 @@ describe('MaybeReader', () => {
 
   test('returns offset if reader did not match', () => {
     const readerMock = jest.fn();
-    readerMock.mockReturnValueOnce(NO_MATCH);
+    readerMock.mockReturnValueOnce(-1);
 
     expect(toReaderFunction(new MaybeReader(readerMock))('aabbcc', 2)).toBe(2);
     expect(readerMock).toHaveBeenCalledTimes(1);

--- a/src/test/readers/or.test.ts
+++ b/src/test/readers/or.test.ts
@@ -1,4 +1,4 @@
-import {NO_MATCH, none, or, OrReader, Reader, text, toReaderFunction} from '../../main/readers';
+import {none, or, OrReader, Reader, text, toReaderFunction} from '../../main/readers';
 
 describe('or', () => {
 
@@ -21,7 +21,7 @@ describe('OrReader', () => {
 
   test('returns after the first match', () => {
     const readerMock = jest.fn();
-    readerMock.mockReturnValueOnce(NO_MATCH);
+    readerMock.mockReturnValueOnce(-1);
     readerMock.mockReturnValueOnce(2);
     readerMock.mockReturnValueOnce(4);
 
@@ -29,17 +29,17 @@ describe('OrReader', () => {
     expect(readerMock).toHaveBeenCalledTimes(2);
   });
 
-  test('returns NO_MATCH', () => {
+  test('returns -1', () => {
     const readerMock = jest.fn();
-    readerMock.mockReturnValue(NO_MATCH);
+    readerMock.mockReturnValue(-1);
 
-    expect(toReaderFunction(new OrReader([readerMock, readerMock]))('aabbcc', 2)).toBe(NO_MATCH);
+    expect(toReaderFunction(new OrReader([readerMock, readerMock]))('aabbcc', 2)).toBe(-1);
     expect(readerMock).toHaveBeenCalledTimes(2);
   });
 
   test('returns negative integer as an error result', () => {
     const readerMock = jest.fn();
-    readerMock.mockReturnValueOnce(NO_MATCH);
+    readerMock.mockReturnValueOnce(-1);
     readerMock.mockReturnValueOnce(-2);
     readerMock.mockReturnValueOnce(4);
 
@@ -49,7 +49,7 @@ describe('OrReader', () => {
 
   test('returns non number value as an error result', () => {
     const readerMock = jest.fn();
-    readerMock.mockReturnValueOnce(NO_MATCH);
+    readerMock.mockReturnValueOnce(-1);
     readerMock.mockReturnValueOnce('Error');
     readerMock.mockReturnValueOnce(4);
 

--- a/src/test/readers/or.test.ts
+++ b/src/test/readers/or.test.ts
@@ -37,23 +37,13 @@ describe('OrReader', () => {
     expect(readerMock).toHaveBeenCalledTimes(2);
   });
 
-  test('returns negative integer as an error result', () => {
+  test('returns last non matched offset', () => {
     const readerMock = jest.fn();
     readerMock.mockReturnValueOnce(-1);
     readerMock.mockReturnValueOnce(-2);
     readerMock.mockReturnValueOnce(4);
 
     expect(toReaderFunction(new OrReader([readerMock, readerMock]))('aabbcc', 2)).toBe(-2);
-    expect(readerMock).toHaveBeenCalledTimes(2);
-  });
-
-  test('returns non number value as an error result', () => {
-    const readerMock = jest.fn();
-    readerMock.mockReturnValueOnce(-1);
-    readerMock.mockReturnValueOnce('Error');
-    readerMock.mockReturnValueOnce(4);
-
-    expect(toReaderFunction(new OrReader([readerMock, readerMock]))('aabbcc', 2)).toBe('Error');
     expect(readerMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/test/readers/or.test.ts
+++ b/src/test/readers/or.test.ts
@@ -7,7 +7,7 @@ describe('or', () => {
   });
 
   test('returns single reader', () => {
-    const readerMock: Reader<any, any> = () => 0;
+    const readerMock: Reader<any> = () => 0;
     expect(or(readerMock)).toBe(readerMock);
   });
 

--- a/src/test/readers/regex.test.ts
+++ b/src/test/readers/regex.test.ts
@@ -1,4 +1,4 @@
-import {NO_MATCH, regex, RegexReader, toReaderFunction} from '../../main/readers';
+import {regex, RegexReader, toReaderFunction} from '../../main/readers';
 
 describe('regex', () => {
 
@@ -14,8 +14,8 @@ describe('RegexReader', () => {
 
     expect(read('aaaabc', 3)).toBe(6);
     expect(read('aaaabcde', 3)).toBe(6);
-    expect(read('aaaab', 3)).toBe(NO_MATCH);
-    expect(read('aaaABC', 3)).toBe(NO_MATCH);
+    expect(read('aaaab', 3)).toBe(-1);
+    expect(read('aaaABC', 3)).toBe(-1);
   });
 
   test('starts from the given offset', () => {
@@ -23,6 +23,6 @@ describe('RegexReader', () => {
   });
 
   test('ignores matches that do not start at offset', () => {
-    expect(toReaderFunction(new RegexReader(/abc/y))('aaaabcabc', 5)).toBe(NO_MATCH);
+    expect(toReaderFunction(new RegexReader(/abc/y))('aaaabcabc', 5)).toBe(-1);
   });
 });

--- a/src/test/readers/seq.test.ts
+++ b/src/test/readers/seq.test.ts
@@ -12,7 +12,7 @@ describe('seq', () => {
   });
 
   test('returns reader', () => {
-    const readerMock: Reader<any, any> = () => 0;
+    const readerMock: Reader<any> = () => 0;
     expect(seq(readerMock)).toBe(readerMock);
   });
 
@@ -35,26 +35,6 @@ describe('SeqReader', () => {
 
   test('allows readers to return the same offset', () => {
     expect(toReaderFunction(new SeqReader([() => 2, () => 4]))('aabbcc', 2)).toBe(4);
-  });
-
-  test('returns negative integer as an error result', () => {
-    const readerMock = jest.fn();
-    readerMock.mockReturnValueOnce(4);
-    readerMock.mockReturnValueOnce('Error');
-    readerMock.mockReturnValueOnce(5);
-
-    expect(toReaderFunction(new SeqReader([readerMock, readerMock, readerMock]))('aabbcc', 2)).toBe('Error');
-    expect(readerMock).toHaveBeenCalledTimes(2);
-  });
-
-  test('returns non number value as an error result', () => {
-    const readerMock = jest.fn();
-    readerMock.mockReturnValueOnce(4);
-    readerMock.mockReturnValueOnce('123');
-    readerMock.mockReturnValueOnce(5);
-
-    expect(toReaderFunction(new SeqReader([readerMock, readerMock, readerMock]))('aabbcc', 2)).toBe('123');
-    expect(readerMock).toHaveBeenCalledTimes(2);
   });
 
   test('can use inline readers', () => {

--- a/src/test/readers/seq.test.ts
+++ b/src/test/readers/seq.test.ts
@@ -1,4 +1,4 @@
-import {never, NO_MATCH, none, Reader, seq, SeqReader, text, toReaderFunction} from '../../main/readers';
+import {never, none, Reader, seq, SeqReader, text, toReaderFunction} from '../../main/readers';
 
 describe('seq', () => {
 
@@ -26,10 +26,10 @@ describe('SeqReader', () => {
   test('fails if any of readers fail', () => {
     const readerMock = jest.fn();
     readerMock.mockReturnValueOnce(4);
-    readerMock.mockReturnValueOnce(NO_MATCH);
+    readerMock.mockReturnValueOnce(-1);
     readerMock.mockReturnValueOnce(5);
 
-    expect(toReaderFunction(new SeqReader([readerMock, readerMock, readerMock]))('aabbcc', 2)).toBe(NO_MATCH);
+    expect(toReaderFunction(new SeqReader([readerMock, readerMock, readerMock]))('aabbcc', 2)).toBe(-1);
     expect(readerMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/test/readers/text.test.ts
+++ b/src/test/readers/text.test.ts
@@ -1,11 +1,4 @@
-import {
-  CaseInsensitiveTextReader,
-  CaseSensitiveTextReader,
-  NO_MATCH,
-  none,
-  text,
-  toReaderFunction
-} from '../../main/readers';
+import {CaseInsensitiveTextReader, CaseSensitiveTextReader, none, text, toReaderFunction} from '../../main/readers';
 
 describe('text', () => {
 
@@ -34,8 +27,8 @@ describe('CaseSensitiveTextReader', () => {
 
     expect(read('aaaabc', 3)).toBe(6);
     expect(read('aaaabcde', 3)).toBe(6);
-    expect(read('aaaab', 3)).toBe(NO_MATCH);
-    expect(read('aaaABC', 3)).toBe(NO_MATCH);
+    expect(read('aaaab', 3)).toBe(-1);
+    expect(read('aaaABC', 3)).toBe(-1);
   });
 });
 
@@ -46,6 +39,6 @@ describe('CaseInsensitiveTextReader', () => {
 
     expect(read('AAAABC', 3)).toBe(6);
     expect(read('AAAABCDE', 3)).toBe(6);
-    expect(read('AAAAB', 3)).toBe(NO_MATCH);
+    expect(read('AAAAB', 3)).toBe(-1);
   });
 });

--- a/src/test/readers/until.test.ts
+++ b/src/test/readers/until.test.ts
@@ -1,7 +1,6 @@
 import {
   char,
   never,
-  NO_MATCH,
   none,
   text,
   toReaderFunction,
@@ -63,8 +62,8 @@ describe('UntilReader', () => {
 
   test('advances reader by one char on each iteration', () => {
     const readerMock = jest.fn();
-    readerMock.mockReturnValueOnce(NO_MATCH);
-    readerMock.mockReturnValueOnce(NO_MATCH);
+    readerMock.mockReturnValueOnce(-1);
+    readerMock.mockReturnValueOnce(-1);
     readerMock.mockReturnValueOnce(4);
 
     expect(toReaderFunction(new UntilReader(readerMock, false))('aaaa', 0)).toBe(2);
@@ -74,8 +73,8 @@ describe('UntilReader', () => {
 
   test('reads inclusive', () => {
     const readerMock = jest.fn();
-    readerMock.mockReturnValueOnce(NO_MATCH);
-    readerMock.mockReturnValueOnce(NO_MATCH);
+    readerMock.mockReturnValueOnce(-1);
+    readerMock.mockReturnValueOnce(-1);
     readerMock.mockReturnValueOnce(77);
 
     expect(toReaderFunction(new UntilReader(readerMock, true))('aaaa', 0)).toBe(77);

--- a/src/test/readme.test.ts
+++ b/src/test/readme.test.ts
@@ -2,23 +2,14 @@ import {all, char, createTokenizer, maybe, or, Rule, seq, text, TokenHandler} fr
 
 describe('Readme', () => {
 
-  const tokenCallbackMock = jest.fn();
-  const errorCallbackMock = jest.fn();
-  const unrecognizedTokenCallbackMock = jest.fn();
+  const handlerMock = jest.fn();
 
-  const handler: TokenHandler = {
-    token(type, chunk, offset, length, context, state) {
-      tokenCallbackMock(type, state.chunkOffset + offset, length, context);
-    },
-    unrecognizedToken(chunk, offset, context, state) {
-      unrecognizedTokenCallbackMock(state.chunkOffset + offset, context);
-    }
+  const handler: TokenHandler = (type, chunk, offset, length, context, state) => {
+    handlerMock(type, state.chunkOffset + offset, length, context);
   };
 
   beforeEach(() => {
-    tokenCallbackMock.mockRestore();
-    errorCallbackMock.mockRestore();
-    unrecognizedTokenCallbackMock.mockRestore();
+    handlerMock.mockRestore();
   });
 
   test('Overview', () => {
@@ -85,10 +76,10 @@ describe('Readme', () => {
     tokenizer.write('777; 42', handler, state);
     tokenizer.end(handler, state);
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(3);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(1, 'NUMBER', 0, 7, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(2, 'NUMBER', 9, 4, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(3, 'NUMBER', 15, 2, undefined);
+    expect(handlerMock).toHaveBeenCalledTimes(3);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'NUMBER', 0, 7, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'NUMBER', 9, 4, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'NUMBER', 15, 2, undefined);
   });
 
   test('Usage', () => {
@@ -128,26 +119,21 @@ describe('Readme', () => {
 
     tokenize('foo;123;bar;456', handler);
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(7);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(1, 'ALPHA', 0, 3, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(2, 'SEMICOLON', 3, 1, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(3, 'INTEGER', 4, 3, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(4, 'SEMICOLON', 7, 1, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(5, 'ALPHA', 8, 3, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(6, 'SEMICOLON', 11, 1, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(7, 'INTEGER', 12, 3, undefined);
+    expect(handlerMock).toHaveBeenCalledTimes(7);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'ALPHA', 0, 3, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'SEMICOLON', 3, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'INTEGER', 4, 3, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(4, 'SEMICOLON', 7, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(5, 'ALPHA', 8, 3, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(6, 'SEMICOLON', 11, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(7, 'INTEGER', 12, 3, undefined);
 
-    expect(unrecognizedTokenCallbackMock).not.toHaveBeenCalled();
-
-    tokenCallbackMock.mockReset();
+    handlerMock.mockReset();
 
     tokenize('abcd__', handler);
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(1);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(1, 'ALPHA', 0, 4, undefined);
-
-    expect(unrecognizedTokenCallbackMock).toHaveBeenCalledTimes(1);
-    expect(unrecognizedTokenCallbackMock).toHaveBeenNthCalledWith(1, 4, undefined);
+    expect(handlerMock).toHaveBeenCalledTimes(1);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'ALPHA', 0, 4, undefined);
   });
 
   test('Stages', () => {
@@ -179,23 +165,18 @@ describe('Readme', () => {
 
     tokenize('foobarfoobar', handler);
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(4);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(1, 'FOO', 0, 3, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(2, 'BAR', 3, 3, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(3, 'FOO', 6, 3, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(4, 'BAR', 9, 3, undefined);
+    expect(handlerMock).toHaveBeenCalledTimes(4);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'FOO', 0, 3, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'BAR', 3, 3, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'FOO', 6, 3, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(4, 'BAR', 9, 3, undefined);
 
-    expect(unrecognizedTokenCallbackMock).not.toHaveBeenCalled();
-
-    tokenCallbackMock.mockReset();
+    handlerMock.mockReset();
 
     tokenize('foofoo', handler);
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(1);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(1, 'FOO', 0, 3, undefined);
-
-    expect(unrecognizedTokenCallbackMock).toHaveBeenCalledTimes(1);
-    expect(unrecognizedTokenCallbackMock).toHaveBeenNthCalledWith(1, 3, undefined);
+    expect(handlerMock).toHaveBeenCalledTimes(1);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'FOO', 0, 3, undefined);
   });
 
   test('Undefined stages', () => {
@@ -233,15 +214,13 @@ describe('Readme', () => {
 
     tokenize('foo  bar  foo  bar', handler);
 
-    expect(tokenCallbackMock).toHaveBeenCalledTimes(7);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(1, 'FOO', 0, 3, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(2, 'SPACE', 3, 2, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(3, 'BAR', 5, 3, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(4, 'SPACE', 8, 2, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(5, 'FOO', 10, 3, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(6, 'SPACE', 13, 2, undefined);
-    expect(tokenCallbackMock).toHaveBeenNthCalledWith(7, 'BAR', 15, 3, undefined);
-
-    expect(unrecognizedTokenCallbackMock).not.toHaveBeenCalled();
+    expect(handlerMock).toHaveBeenCalledTimes(7);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'FOO', 0, 3, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'SPACE', 3, 2, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'BAR', 5, 3, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(4, 'SPACE', 8, 2, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(5, 'FOO', 10, 3, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(6, 'SPACE', 13, 2, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(7, 'BAR', 15, 3, undefined);
   });
 });

--- a/src/test/readme.test.ts
+++ b/src/test/readme.test.ts
@@ -10,9 +10,6 @@ describe('Readme', () => {
     token(type, chunk, offset, length, context, state) {
       tokenCallbackMock(type, state.chunkOffset + offset, length, context);
     },
-    error(type, chunk, offset, errorCode, context, state) {
-      errorCallbackMock(type, state.chunkOffset + offset, errorCode, context);
-    },
     unrecognizedToken(chunk, offset, context, state) {
       unrecognizedTokenCallbackMock(state.chunkOffset + offset, context);
     }
@@ -83,10 +80,9 @@ describe('Readme', () => {
         'value'
     );
 
-    let state;
-    state = tokenizer.write('123', handler);
-    state = tokenizer.write('.456; +', handler, state);
-    state = tokenizer.write('777; 42', handler, state);
+    const state = tokenizer.write('123', handler);
+    tokenizer.write('.456; +', handler, state);
+    tokenizer.write('777; 42', handler, state);
     tokenizer.end(handler, state);
 
     expect(tokenCallbackMock).toHaveBeenCalledTimes(3);

--- a/src/test/rules/compileRuleIterator.test.ts
+++ b/src/test/rules/compileRuleIterator.test.ts
@@ -1,4 +1,4 @@
-import {all, Reader, Rule, seq, text} from '../../main';
+import {all, Reader, seq, text} from '../../main';
 import {compileRuleIterator, createRuleTree, TokenHandler, TokenizerState} from '../../main/rules';
 
 describe('compileRuleIterator', () => {
@@ -15,12 +15,9 @@ describe('compileRuleIterator', () => {
 
   test('emits tokens', () => {
 
-    const ruleA: Rule = {type: 'TypeA', reader: all(text('a'))};
-    const ruleB: Rule = {type: 'TypeB', reader: all(text('b'))};
-
     const ruleIterator = compileRuleIterator(createRuleTree([
-      ruleA,
-      ruleB,
+      {type: 'TYPE_A', reader: all(text('a'))},
+      {type: 'TYPE_B', reader: all(text('b'))},
     ]));
 
     const state: TokenizerState = {
@@ -33,10 +30,10 @@ describe('compileRuleIterator', () => {
     ruleIterator(state, handler, undefined);
 
     expect(handlerMock).toHaveBeenCalledTimes(4);
-    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TypeA', 0, 1, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TypeB', 1, 1, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TypeA', 2, 2, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(4, 'TypeB', 4, 2, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TYPE_A', 0, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TYPE_B', 1, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TYPE_A', 2, 2, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(4, 'TYPE_B', 4, 2, undefined);
 
     expect(state).toEqual({
       chunk: 'abaabb',
@@ -48,8 +45,9 @@ describe('compileRuleIterator', () => {
 
   test('reads a non-empty token from the string at chunk start in streaming mode', () => {
 
-    const ruleA: Rule = {type: 'TypeA', reader: text('a')};
-    const ruleIterator = compileRuleIterator(createRuleTree([ruleA]));
+    const ruleIterator = compileRuleIterator(createRuleTree([
+      {type: 'TYPE_A', reader: text('a')},
+    ]));
 
     const state: TokenizerState = {
       chunk: 'aaa',
@@ -61,8 +59,8 @@ describe('compileRuleIterator', () => {
     ruleIterator(state, handler, undefined, true);
 
     expect(handlerMock).toHaveBeenCalledTimes(2);
-    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TypeA', 0, 1, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TypeA', 1, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TYPE_A', 0, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TYPE_A', 1, 1, undefined);
 
     expect(state).toEqual({
       chunk: 'aaa',
@@ -74,8 +72,9 @@ describe('compileRuleIterator', () => {
 
   test('reads a non-empty token from the string at chunk start in non-streaming mode', () => {
 
-    const ruleA: Rule = {type: 'TypeA', reader: text('a')};
-    const ruleIterator = compileRuleIterator(createRuleTree([ruleA]));
+    const ruleIterator = compileRuleIterator(createRuleTree([
+      {type: 'TYPE_A', reader: text('a')},
+    ]));
 
     const state: TokenizerState = {
       chunk: 'aaa',
@@ -87,9 +86,9 @@ describe('compileRuleIterator', () => {
     ruleIterator(state, handler, undefined);
 
     expect(handlerMock).toHaveBeenCalledTimes(3);
-    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TypeA', 0, 1, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TypeA', 1, 1, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TypeA', 2, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TYPE_A', 0, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TYPE_A', 1, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TYPE_A', 2, 1, undefined);
 
     expect(state).toEqual({
       chunk: 'aaa',
@@ -101,8 +100,9 @@ describe('compileRuleIterator', () => {
 
   test('reads a non-empty token from the string with offset in streaming mode', () => {
 
-    const ruleA: Rule = {type: 'TypeA', reader: text('a')};
-    const ruleIterator = compileRuleIterator(createRuleTree([ruleA]));
+    const ruleIterator = compileRuleIterator(createRuleTree([
+      {type: 'TYPE_A', reader: text('a')},
+    ]));
 
     const state: TokenizerState = {
       chunk: 'bbaaa',
@@ -114,9 +114,9 @@ describe('compileRuleIterator', () => {
     ruleIterator(state, handler, undefined);
 
     expect(handlerMock).toHaveBeenCalledTimes(3);
-    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TypeA', 1002, 1, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TypeA', 1003, 1, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TypeA', 1004, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TYPE_A', 1002, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TYPE_A', 1003, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TYPE_A', 1004, 1, undefined);
 
     expect(state).toEqual({
       chunk: 'bbaaa',
@@ -127,47 +127,48 @@ describe('compileRuleIterator', () => {
   });
 
   test('respects literal stages', () => {
-    const ruleA: Rule<string, string> = {type: 'TypeA', reader: text('a'), on: ['A'], to: 'B'};
-    const ruleB: Rule<string, string> = {type: 'TypeB', reader: text('b'), on: ['B'], to: 'A'};
 
-    const ruleIterator = compileRuleIterator(createRuleTree([ruleA, ruleB]));
+    const ruleIterator = compileRuleIterator(createRuleTree([
+      {type: 'TYPE_A', reader: text('a'), on: ['STAGE_A'], to: 'STAGE_B'},
+      {type: 'TYPE_B', reader: text('b'), on: ['STAGE_B'], to: 'STAGE_A'},
+    ]));
 
-    const state: TokenizerState<string> = {
+    const state: TokenizerState = {
       chunk: 'ababbbb',
       offset: 0,
       chunkOffset: 0,
-      stage: 'A',
+      stage: 'STAGE_A',
     };
 
     ruleIterator(state, handler, undefined, true);
 
     expect(handlerMock).toHaveBeenCalledTimes(3);
-    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TypeA', 0, 1, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TypeB', 1, 1, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TypeA', 2, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TYPE_A', 0, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TYPE_B', 1, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TYPE_A', 2, 1, undefined);
 
     expect(state).toEqual({
       chunk: 'ababbbb',
       offset: 3,
       chunkOffset: 0,
-      stage: 'B',
+      stage: 'STAGE_B',
     });
   });
 
   test('respects computed stages', () => {
-    const ruleAToMock = jest.fn(() => 'B');
-    const ruleBToMock = jest.fn(() => 'A');
+    const ruleAToMock = jest.fn(() => 'STAGE_B');
+    const ruleBToMock = jest.fn(() => 'STAGE_A');
 
-    const ruleA: Rule<string, string, symbol> = {type: 'TypeA', reader: text('a'), on: ['A'], to: ruleAToMock};
-    const ruleB: Rule<string, string, symbol> = {type: 'TypeB', reader: text('b'), on: ['B'], to: ruleBToMock};
+    const ruleIterator = compileRuleIterator(createRuleTree([
+      {type: 'TYPE_A', reader: text('a'), on: ['STAGE_A'], to: ruleAToMock},
+      {type: 'TYPE_B', reader: text('b'), on: ['STAGE_B'], to: ruleBToMock},
+    ]));
 
-    const ruleIterator = compileRuleIterator(createRuleTree([ruleA, ruleB]));
-
-    const state: TokenizerState<string> = {
+    const state: TokenizerState = {
       chunk: 'ababbbb',
       offset: 0,
       chunkOffset: 0,
-      stage: 'A',
+      stage: 'STAGE_A',
     };
 
     const context = Symbol('context');
@@ -175,9 +176,9 @@ describe('compileRuleIterator', () => {
     ruleIterator(state, handler, context, true);
 
     expect(handlerMock).toHaveBeenCalledTimes(3);
-    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TypeA', 0, 1, context);
-    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TypeB', 1, 1, context);
-    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TypeA', 2, 1, context);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TYPE_A', 0, 1, context);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TYPE_B', 1, 1, context);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TYPE_A', 2, 1, context);
 
     expect(ruleAToMock).toHaveBeenCalledTimes(2);
     expect(ruleAToMock).toHaveBeenNthCalledWith(1, 'ababbbb', 0, 1, context, expect.anything());
@@ -191,18 +192,18 @@ describe('compileRuleIterator', () => {
       chunk: 'ababbbb',
       offset: 3,
       chunkOffset: 0,
-      stage: 'B',
+      stage: 'STAGE_B',
     });
   });
 
   test('optimizes rule prefixes', () => {
 
-    const prefixReaderMock: Reader<any> = jest.fn((input, offset) => offset + 1);
+    const readerMock: Reader<any> = jest.fn((input, offset) => offset + 1);
 
-    const ruleA: Rule = {type: 'TypeA', reader: seq(prefixReaderMock, text('a'))};
-    const ruleB: Rule = {type: 'TypeB', reader: seq(prefixReaderMock, text('b'))};
-
-    const ruleIterator = compileRuleIterator(createRuleTree([ruleA, ruleB]));
+    const ruleIterator = compileRuleIterator(createRuleTree([
+      {type: 'TYPE_A', reader: seq(readerMock, text('a'))},
+      {type: 'TYPE_B', reader: seq(readerMock, text('b'))},
+    ]));
 
     const state: TokenizerState = {
       chunk: '_b',
@@ -214,7 +215,7 @@ describe('compileRuleIterator', () => {
     ruleIterator(state, handler, undefined);
 
     expect(handlerMock).toHaveBeenCalledTimes(1);
-    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TypeB', 0, 2, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TYPE_B', 0, 2, undefined);
 
     expect(state).toEqual({
       chunk: '_b',
@@ -226,10 +227,10 @@ describe('compileRuleIterator', () => {
 
   test('does not emit tokens for silent rules', () => {
 
-    const ruleA: Rule = {type: 'TypeA', reader: text('a')};
-    const ruleB: Rule = {type: 'TypeB', reader: text('b'), silent: true};
-
-    const ruleIterator = compileRuleIterator(createRuleTree([ruleA, ruleB]));
+    const ruleIterator = compileRuleIterator(createRuleTree([
+      {type: 'TYPE_A', reader: text('a')},
+      {type: 'TYPE_B', reader: text('b'), silent: true},
+    ]));
 
     const state: TokenizerState = {
       chunk: 'ababa',
@@ -241,15 +242,77 @@ describe('compileRuleIterator', () => {
     ruleIterator(state, handler, undefined);
 
     expect(handlerMock).toHaveBeenCalledTimes(3);
-    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TypeA', 0, 1, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TypeA', 2, 1, undefined);
-    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TypeA', 4, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(1, 'TYPE_A', 0, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(2, 'TYPE_A', 2, 1, undefined);
+    expect(handlerMock).toHaveBeenNthCalledWith(3, 'TYPE_A', 4, 1, undefined);
 
     expect(state).toEqual({
       chunk: 'ababa',
       offset: 5,
       chunkOffset: 0,
       stage: undefined,
+    });
+  });
+
+  test('state is uncorrupted when an error is thrown in a token handler', () => {
+
+    const ruleIterator = compileRuleIterator(createRuleTree([
+      {reader: text('a'), on: ['STAGE_B'], to: 'STAGE_A'},
+      {reader: text('b'), on: ['STAGE_A'], to: 'STAGE_B'},
+    ]));
+
+    const state: TokenizerState = {
+      chunk: 'ababa',
+      offset: 0,
+      chunkOffset: 0,
+      stage: 'STAGE_B',
+    };
+
+    handlerMock.mockImplementationOnce(() => undefined);
+    handlerMock.mockImplementationOnce(() => undefined);
+    handlerMock.mockImplementationOnce(() => undefined);
+    handlerMock.mockImplementationOnce(() => {
+      throw new Error();
+    });
+
+    expect(() => ruleIterator(state, handler, undefined)).toThrow();
+
+    expect(state).toEqual({
+      chunk: 'ababa',
+      offset: 3,
+      chunkOffset: 0,
+      stage: 'STAGE_A',
+    });
+  });
+
+  test('state is uncorrupted when an error is thrown in a stage provider', () => {
+
+    const toMock = jest.fn(() => 'STAGE_B');
+
+    const ruleIterator = compileRuleIterator(createRuleTree([
+      {reader: text('a'), on: ['STAGE_B'], to: 'STAGE_A'},
+      {reader: text('b'), on: ['STAGE_A'], to: toMock},
+    ]));
+
+    toMock.mockImplementationOnce(() => 'STAGE_B');
+    toMock.mockImplementationOnce(() => {
+      throw new Error();
+    });
+
+    const state: TokenizerState = {
+      chunk: 'ababa',
+      offset: 0,
+      chunkOffset: 0,
+      stage: 'STAGE_B',
+    };
+
+    expect(() => ruleIterator(state, handler, undefined)).toThrow();
+
+    expect(state).toEqual({
+      chunk: 'ababa',
+      offset: 3,
+      chunkOffset: 0,
+      stage: 'STAGE_A',
     });
   });
 });

--- a/src/test/rules/createRuleTree.test.ts
+++ b/src/test/rules/createRuleTree.test.ts
@@ -16,7 +16,6 @@ describe('createRuleTree', () => {
         {
           readers: [reader1, reader2],
           rule,
-          ruleId: 0,
         },
       ],
     };
@@ -36,7 +35,6 @@ describe('createRuleTree', () => {
         [{
           readers: [reader1, reader2],
           rule,
-          ruleId: 0,
         }],
       ],
       branches: [],
@@ -62,12 +60,10 @@ describe('createRuleTree', () => {
             {
               readers: [reader12],
               rule: rule1,
-              ruleId: 0,
             },
             {
               readers: [reader22],
               rule: rule2,
-              ruleId: 1,
             },
           ],
         }],
@@ -93,13 +89,11 @@ describe('createRuleTree', () => {
         [{
           readers: [reader1, reader12],
           rule: rule1,
-          ruleId: 0,
         }],
         // B
         [{
           readers: [reader1, reader22],
           rule: rule2,
-          ruleId: 1,
         }],
       ],
       branches: [],
@@ -125,12 +119,10 @@ describe('createRuleTree', () => {
             {
               readers: [reader12],
               rule: rule1,
-              ruleId: 0,
             },
             {
               readers: [reader22],
               rule: rule2,
-              ruleId: 1,
             },
           ],
         }],
@@ -138,7 +130,6 @@ describe('createRuleTree', () => {
       branches: [{
         readers: [reader1, reader22],
         rule: rule2,
-        ruleId: 1,
       }],
     };
 
@@ -158,11 +149,10 @@ describe('appendRule', () => {
       {
         readers: [reader1, reader2],
         rule,
-        ruleId: 777,
       },
     ];
 
-    expect(appendRule([], rule, 777)).toEqual(branches);
+    expect(appendRule([], rule)).toEqual(branches);
   });
 
   test('appends a rule without a common prefix', () => {
@@ -177,16 +167,14 @@ describe('appendRule', () => {
       {
         readers: [reader11, reader12],
         rule: rule1,
-        ruleId: 777,
       },
       {
         readers: [reader21],
         rule: rule2,
-        ruleId: 888,
       },
     ];
 
-    expect(appendRule(appendRule([], rule1, 777), rule2, 888)).toEqual(branches);
+    expect(appendRule(appendRule([], rule1), rule2)).toEqual(branches);
   });
 
   test('appends a rule with a common prefix', () => {
@@ -204,18 +192,16 @@ describe('appendRule', () => {
           {
             readers: [reader12],
             rule: rule1,
-            ruleId: 777,
           },
           {
             readers: [reader21],
             rule: rule2,
-            ruleId: 888,
           },
         ]
       },
     ];
 
-    expect(appendRule(appendRule([], rule1, 777), rule2, 888)).toEqual(branches);
+    expect(appendRule(appendRule([], rule1), rule2)).toEqual(branches);
   });
 
   test('appends termination rule', () => {
@@ -232,15 +218,13 @@ describe('appendRule', () => {
           {
             readers: [reader12],
             rule: rule1,
-            ruleId: 777,
           },
         ],
         rule: rule2,
-        ruleId: 888,
       },
     ];
 
-    expect(appendRule(appendRule([], rule1, 777), rule2, 888)).toEqual(branches);
+    expect(appendRule(appendRule([], rule1), rule2)).toEqual(branches);
   });
 
   test('ignores absorbed rules', () => {
@@ -254,10 +238,9 @@ describe('appendRule', () => {
       {
         readers: [reader1],
         rule: rule1,
-        ruleId: 777,
       },
     ];
 
-    expect(appendRule(appendRule([], rule1, 777), rule2, 888)).toEqual(branches);
+    expect(appendRule(appendRule([], rule1), rule2)).toEqual(branches);
   });
 });

--- a/src/test/rules/createRuleTree.test.ts
+++ b/src/test/rules/createRuleTree.test.ts
@@ -7,7 +7,7 @@ describe('createRuleTree', () => {
     const reader1 = () => 0;
     const reader2 = () => 0;
 
-    const rule: Rule = {type: 'Type', reader: seq(reader1, reader2)};
+    const rule: Rule = {reader: seq(reader1, reader2)};
 
     const ruleIterationPlan: RuleTree<any, any, any> = {
       stages: [],
@@ -27,10 +27,10 @@ describe('createRuleTree', () => {
     const reader1 = () => 0;
     const reader2 = () => 0;
 
-    const rule: Rule<unknown, string> = {type: 'Type', reader: seq(reader1, reader2), on: ['A']};
+    const rule: Rule<unknown, string> = {reader: seq(reader1, reader2), on: ['STAGE_A']};
 
     const ruleIterationPlan: RuleTree<any, any, any> = {
-      stages: ['A'],
+      stages: ['STAGE_A'],
       branchesOnStage: [
         [{
           readers: [reader1, reader2],
@@ -48,11 +48,11 @@ describe('createRuleTree', () => {
     const reader12 = () => 0;
     const reader22 = () => 0;
 
-    const rule1: Rule<unknown, string> = {type: 'Type1', reader: seq(reader1, reader12), on: ['A']};
-    const rule2: Rule<unknown, string> = {type: 'Type2', reader: seq(reader1, reader22), on: ['A']};
+    const rule1: Rule<unknown, string> = {reader: seq(reader1, reader12), on: ['STAGE_A']};
+    const rule2: Rule<unknown, string> = {reader: seq(reader1, reader22), on: ['STAGE_A']};
 
     const ruleIterationPlan: RuleTree<any, any, any> = {
-      stages: ['A'],
+      stages: ['STAGE_A'],
       branchesOnStage: [
         [{
           readers: [reader1],
@@ -79,18 +79,18 @@ describe('createRuleTree', () => {
     const reader12 = () => 0;
     const reader22 = () => 0;
 
-    const rule1: Rule<unknown, string> = {type: 'Type', reader: seq(reader1, reader12), on: ['A']};
-    const rule2: Rule<unknown, string> = {type: 'Type', reader: seq(reader1, reader22), on: ['B']};
+    const rule1: Rule<unknown, string> = {reader: seq(reader1, reader12), on: ['STAGE_A']};
+    const rule2: Rule<unknown, string> = {reader: seq(reader1, reader22), on: ['STAGE_B']};
 
     const ruleIterationPlan: RuleTree<any, any, any> = {
-      stages: ['A', 'B'],
+      stages: ['STAGE_A', 'STAGE_B'],
       branchesOnStage: [
-        // A
+        // STAGE_A
         [{
           readers: [reader1, reader12],
           rule: rule1,
         }],
-        // B
+        // STAGE_B
         [{
           readers: [reader1, reader22],
           rule: rule2,
@@ -107,11 +107,11 @@ describe('createRuleTree', () => {
     const reader12 = () => 0;
     const reader22 = () => 0;
 
-    const rule1: Rule<unknown, string> = {type: 'Type1', reader: seq(reader1, reader12), on: ['A']};
-    const rule2: Rule<unknown, string> = {type: 'Type2', reader: seq(reader1, reader22)};
+    const rule1: Rule<unknown, string> = {reader: seq(reader1, reader12), on: ['STAGE_A']};
+    const rule2: Rule<unknown, string> = {reader: seq(reader1, reader22)};
 
     const ruleIterationPlan: RuleTree<any, any, any> = {
-      stages: ['A'],
+      stages: ['STAGE_A'],
       branchesOnStage: [
         [{
           readers: [reader1],
@@ -143,7 +143,7 @@ describe('appendRule', () => {
     const reader1 = () => 0;
     const reader2 = () => 0;
 
-    const rule: Rule = {type: 'Type', reader: seq(reader1, reader2)};
+    const rule: Rule = {reader: seq(reader1, reader2)};
 
     const branches: RuleBranch<any, any, any>[] = [
       {
@@ -160,8 +160,8 @@ describe('appendRule', () => {
     const reader12 = () => 0;
     const reader21 = () => 0;
 
-    const rule1: Rule = {type: 'Type1', reader: seq(reader11, reader12)};
-    const rule2: Rule = {type: 'Type2', reader: reader21};
+    const rule1: Rule = {reader: seq(reader11, reader12)};
+    const rule2: Rule = {reader: reader21};
 
     const branches: RuleBranch<any, any, any>[] = [
       {
@@ -182,8 +182,8 @@ describe('appendRule', () => {
     const reader12 = () => 0;
     const reader21 = () => 0;
 
-    const rule1: Rule = {type: 'Type1', reader: seq(reader1, reader12)};
-    const rule2: Rule = {type: 'Type2', reader: seq(reader1, reader21)};
+    const rule1: Rule = {reader: seq(reader1, reader12)};
+    const rule2: Rule = {reader: seq(reader1, reader21)};
 
     const branches: RuleBranch<any, any, any>[] = [
       {
@@ -208,8 +208,8 @@ describe('appendRule', () => {
     const reader1 = () => 0;
     const reader12 = () => 0;
 
-    const rule1: Rule = {type: 'Type1', reader: seq(reader1, reader12)};
-    const rule2: Rule = {type: 'Type2', reader: reader1};
+    const rule1: Rule = {reader: seq(reader1, reader12)};
+    const rule2: Rule = {reader: reader1};
 
     const branches: RuleBranch<any, any, any>[] = [
       {
@@ -231,8 +231,8 @@ describe('appendRule', () => {
     const reader1 = () => 0;
     const reader22 = () => 0;
 
-    const rule1: Rule = {type: 'Type1', reader: reader1};
-    const rule2: Rule = {type: 'Type2', reader: seq(reader1, reader22)};
+    const rule1: Rule = {reader: reader1};
+    const rule2: Rule = {reader: seq(reader1, reader22)};
 
     const branches: RuleBranch<any, any, any>[] = [
       {

--- a/src/test/rules/createRuleTree.test.ts
+++ b/src/test/rules/createRuleTree.test.ts
@@ -9,7 +9,7 @@ describe('createRuleTree', () => {
 
     const rule: Rule = {type: 'Type', reader: seq(reader1, reader2)};
 
-    const ruleIterationPlan: RuleTree<any, any, any, any> = {
+    const ruleIterationPlan: RuleTree<any, any, any> = {
       stages: [],
       branchesByStageIndex: [],
       branches: [
@@ -30,7 +30,7 @@ describe('createRuleTree', () => {
 
     const rule: Rule<unknown, string> = {type: 'Type', reader: seq(reader1, reader2), on: ['A']};
 
-    const ruleIterationPlan: RuleTree<any, any, any, any> = {
+    const ruleIterationPlan: RuleTree<any, any, any> = {
       stages: ['A'],
       branchesByStageIndex: [
         [{
@@ -53,7 +53,7 @@ describe('createRuleTree', () => {
     const rule1: Rule<unknown, string> = {type: 'Type1', reader: seq(reader1, reader12), on: ['A']};
     const rule2: Rule<unknown, string> = {type: 'Type2', reader: seq(reader1, reader22), on: ['A']};
 
-    const ruleIterationPlan: RuleTree<any, any, any, any> = {
+    const ruleIterationPlan: RuleTree<any, any, any> = {
       stages: ['A'],
       branchesByStageIndex: [
         [{
@@ -86,7 +86,7 @@ describe('createRuleTree', () => {
     const rule1: Rule<unknown, string> = {type: 'Type', reader: seq(reader1, reader12), on: ['A']};
     const rule2: Rule<unknown, string> = {type: 'Type', reader: seq(reader1, reader22), on: ['B']};
 
-    const ruleIterationPlan: RuleTree<any, any, any, any> = {
+    const ruleIterationPlan: RuleTree<any, any, any> = {
       stages: ['A', 'B'],
       branchesByStageIndex: [
         // A
@@ -116,7 +116,7 @@ describe('createRuleTree', () => {
     const rule1: Rule<unknown, string> = {type: 'Type1', reader: seq(reader1, reader12), on: ['A']};
     const rule2: Rule<unknown, string> = {type: 'Type2', reader: seq(reader1, reader22)};
 
-    const ruleIterationPlan: RuleTree<any, any, any, any> = {
+    const ruleIterationPlan: RuleTree<any, any, any> = {
       stages: ['A'],
       branchesByStageIndex: [
         [{
@@ -154,7 +154,7 @@ describe('appendRule', () => {
 
     const rule: Rule = {type: 'Type', reader: seq(reader1, reader2)};
 
-    const branches: RuleBranch<any, any, any, any>[] = [
+    const branches: RuleBranch<any, any, any>[] = [
       {
         readers: [reader1, reader2],
         rule,
@@ -173,7 +173,7 @@ describe('appendRule', () => {
     const rule1: Rule = {type: 'Type1', reader: seq(reader11, reader12)};
     const rule2: Rule = {type: 'Type2', reader: reader21};
 
-    const branches: RuleBranch<any, any, any, any>[] = [
+    const branches: RuleBranch<any, any, any>[] = [
       {
         readers: [reader11, reader12],
         rule: rule1,
@@ -197,7 +197,7 @@ describe('appendRule', () => {
     const rule1: Rule = {type: 'Type1', reader: seq(reader1, reader12)};
     const rule2: Rule = {type: 'Type2', reader: seq(reader1, reader21)};
 
-    const branches: RuleBranch<any, any, any, any>[] = [
+    const branches: RuleBranch<any, any, any>[] = [
       {
         readers: [reader1],
         children: [
@@ -225,7 +225,7 @@ describe('appendRule', () => {
     const rule1: Rule = {type: 'Type1', reader: seq(reader1, reader12)};
     const rule2: Rule = {type: 'Type2', reader: reader1};
 
-    const branches: RuleBranch<any, any, any, any>[] = [
+    const branches: RuleBranch<any, any, any>[] = [
       {
         readers: [reader1],
         children: [
@@ -250,7 +250,7 @@ describe('appendRule', () => {
     const rule1: Rule = {type: 'Type1', reader: reader1};
     const rule2: Rule = {type: 'Type2', reader: seq(reader1, reader22)};
 
-    const branches: RuleBranch<any, any, any, any>[] = [
+    const branches: RuleBranch<any, any, any>[] = [
       {
         readers: [reader1],
         rule: rule1,

--- a/src/test/rules/createRuleTree.test.ts
+++ b/src/test/rules/createRuleTree.test.ts
@@ -16,7 +16,7 @@ describe('createRuleTree', () => {
         {
           readers: [reader1, reader2],
           rule,
-          ruleIndex: 0,
+          ruleId: 0,
         },
       ],
     };
@@ -36,7 +36,7 @@ describe('createRuleTree', () => {
         [{
           readers: [reader1, reader2],
           rule,
-          ruleIndex: 0,
+          ruleId: 0,
         }],
       ],
       branches: [],
@@ -62,12 +62,12 @@ describe('createRuleTree', () => {
             {
               readers: [reader12],
               rule: rule1,
-              ruleIndex: 0,
+              ruleId: 0,
             },
             {
               readers: [reader22],
               rule: rule2,
-              ruleIndex: 1,
+              ruleId: 1,
             },
           ],
         }],
@@ -93,13 +93,13 @@ describe('createRuleTree', () => {
         [{
           readers: [reader1, reader12],
           rule: rule1,
-          ruleIndex: 0,
+          ruleId: 0,
         }],
         // B
         [{
           readers: [reader1, reader22],
           rule: rule2,
-          ruleIndex: 1,
+          ruleId: 1,
         }],
       ],
       branches: [],
@@ -125,12 +125,12 @@ describe('createRuleTree', () => {
             {
               readers: [reader12],
               rule: rule1,
-              ruleIndex: 0,
+              ruleId: 0,
             },
             {
               readers: [reader22],
               rule: rule2,
-              ruleIndex: 1,
+              ruleId: 1,
             },
           ],
         }],
@@ -138,7 +138,7 @@ describe('createRuleTree', () => {
       branches: [{
         readers: [reader1, reader22],
         rule: rule2,
-        ruleIndex: 1,
+        ruleId: 1,
       }],
     };
 
@@ -158,7 +158,7 @@ describe('appendRule', () => {
       {
         readers: [reader1, reader2],
         rule,
-        ruleIndex: 777,
+        ruleId: 777,
       },
     ];
 
@@ -177,12 +177,12 @@ describe('appendRule', () => {
       {
         readers: [reader11, reader12],
         rule: rule1,
-        ruleIndex: 777,
+        ruleId: 777,
       },
       {
         readers: [reader21],
         rule: rule2,
-        ruleIndex: 888,
+        ruleId: 888,
       },
     ];
 
@@ -204,12 +204,12 @@ describe('appendRule', () => {
           {
             readers: [reader12],
             rule: rule1,
-            ruleIndex: 777,
+            ruleId: 777,
           },
           {
             readers: [reader21],
             rule: rule2,
-            ruleIndex: 888,
+            ruleId: 888,
           },
         ]
       },
@@ -232,11 +232,11 @@ describe('appendRule', () => {
           {
             readers: [reader12],
             rule: rule1,
-            ruleIndex: 777,
+            ruleId: 777,
           },
         ],
         rule: rule2,
-        ruleIndex: 888,
+        ruleId: 888,
       },
     ];
 
@@ -254,7 +254,7 @@ describe('appendRule', () => {
       {
         readers: [reader1],
         rule: rule1,
-        ruleIndex: 777,
+        ruleId: 777,
       },
     ];
 

--- a/src/test/rules/createRuleTree.test.ts
+++ b/src/test/rules/createRuleTree.test.ts
@@ -11,7 +11,7 @@ describe('createRuleTree', () => {
 
     const ruleIterationPlan: RuleTree<any, any, any> = {
       stages: [],
-      branchesByStageIndex: [],
+      branchesOnStage: [],
       branches: [
         {
           readers: [reader1, reader2],
@@ -32,7 +32,7 @@ describe('createRuleTree', () => {
 
     const ruleIterationPlan: RuleTree<any, any, any> = {
       stages: ['A'],
-      branchesByStageIndex: [
+      branchesOnStage: [
         [{
           readers: [reader1, reader2],
           rule,
@@ -55,7 +55,7 @@ describe('createRuleTree', () => {
 
     const ruleIterationPlan: RuleTree<any, any, any> = {
       stages: ['A'],
-      branchesByStageIndex: [
+      branchesOnStage: [
         [{
           readers: [reader1],
           children: [
@@ -88,7 +88,7 @@ describe('createRuleTree', () => {
 
     const ruleIterationPlan: RuleTree<any, any, any> = {
       stages: ['A', 'B'],
-      branchesByStageIndex: [
+      branchesOnStage: [
         // A
         [{
           readers: [reader1, reader12],
@@ -118,7 +118,7 @@ describe('createRuleTree', () => {
 
     const ruleIterationPlan: RuleTree<any, any, any> = {
       stages: ['A'],
-      branchesByStageIndex: [
+      branchesOnStage: [
         [{
           readers: [reader1],
           children: [


### PR DESCRIPTION
- Numeric token types and stages are inlined without additional variables;
- Embrace `throw` instead of custom errors, since this significantly reduces the number of checks in readers;
- `TokenizerState` is now a mutable object that is properly updated even if a token handler or a stage provider throws an error;
- Evicted `NO_MATCH` since it brought excessive complexity;
- `TokenHandler` is now a function.
